### PR TITLE
Include tests in Travis build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,24 @@
-dist: xenial   # required for Python >= 3.7
+dist: bionic
 language: python
 python:
   - '3.6'
 
-# To install packages which are not on pip
-#before_install:
-#  - sudo apt-get install ...
-#addons:
-#  apt:
-#    update: true
-
-# command to install dependencies
 install:
+  - sudo apt-get install coinor-cbc
   - pip install -r tests/test_requirements.txt
 
-# commands to run tests 
+  # Install specific branch of oemof
+  - git clone https://github.com/oemof/oemof.git
+  - cd oemof
+  - git fetch origin pull/592/head:smoothbranch
+  - git checkout smoothbranch
+  - pip install .
+  - cd ..
+
+  - pip install -r requirements.txt
+
 script:
-  - flake8
-  - pylint */*.py
-#jobs:
-#  include:
-#    - stage: "Tests"                # naming the Tests stage
-#      name: "Linting Tests"            # names the first Tests stage job
-#      script: flake8
-#      script: pylint
-# for later stages
-#    - script: ./integration-tests
-#      name: "Integration Tests"     # names the second Tests stage job
-#    - stage: deploy
-#      name: "Deploy to GCP"
-#      script: ./deploy
-
-# blocklist
-#branches:
-#  except:
-#  - branch_name1
-#  - branch_name2
-
-# safelist
-#branches:
-#  only:
-#  - branch_name1
-#  - branch_name2
+#TODO re-enable flake8
+#- flake8
+#- pylint */*.py
+  - echo "Done!"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ python:
   - '3.6'
 
 install:
-  - sudo apt-get install coinor-cbc
   - pip install -r tests/test_requirements.txt
+
+  # Install CBC solver
+  - sudo apt-get install coinor-cbc
 
   # Install specific branch of oemof
   - git clone https://github.com/oemof/oemof.git
@@ -15,10 +17,12 @@ install:
   - pip install .
   - cd ..
 
+  # Install other smooth dependencies
   - pip install -r requirements.txt
 
 script:
-#TODO re-enable flake8
-#- flake8
-#- pylint */*.py
-  - echo "Done!"
+  # Run pytest in `tests` directory
+  - pytest tests
+
+  #TODO re-enable flake8
+  #- flake8

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,2 +1,2 @@
 flake8
-pylint
+pytest


### PR DESCRIPTION
A `.travis.yml` already existed but it just contained linters. This PR updates the build config with installation instructions for all smooth dependencies and a final call to pytest.

This should help with https://github.com/rl-institut/smooth/issues/45