### PR TITLE
component_electrolyzer includes waste_heat_model #31

### DIFF
--- a/smooth/components/component_electrolyzer.py
+++ b/smooth/components/component_electrolyzer.py
@@ -4,6 +4,7 @@ from .component import Component
 import math
 import numpy as np
 import warnings
+import pyomo.environ as po
 
 class Electrolyzer (Component):
     """ Electrolyzer agents are created through this class """
@@ -18,6 +19,7 @@ class Electrolyzer (Component):
         # Define the busses.
         self.bus_el = None
         self.bus_h2 = None
+        self.bus_th = None
 
         # Max. power [W].
         self.power_max = 100000
@@ -44,6 +46,14 @@ class Electrolyzer (Component):
         self.cur_dens_max_temp = 0.35
         # size of cell surface [cm²].
         self.area_cell = 1500
+        # lumped thermal capacitance C_t [J/K]
+        self.lumped_thermal_capacitance = 625*1e3
+        # source: Ulleberg et al., 'Modeling of advanced alkaline electrolyzer: a system simulation approach', Int. J.
+        # Hydrogen Energy, 2003
+        # resistance to heat transfer R_t [K/W]
+        self.resistance_to_heat_transfer = 0.164
+        # source: Dieguez et al., 'Thermal Performance of a commercial alkaline water electrolyzer: Experimental study
+        # and mathematical modeling', Int. J. Hydrogen Energy, 2008
 
         """ UPDATE PARAMETER DEFAULT VALUES """
         self.set_parameters(params)
@@ -67,6 +77,13 @@ class Electrolyzer (Component):
         self.molality_KOH = 7.64
         # upper heating value in [MJ / kg]
         self.upp_heat_val = 141.8
+        # constant parameters for calculating sensible heat:
+        # molar mass M_O2
+        self.molar_mass_O2 = 31.99880
+        # specific heat at constant pressure [J/(kg*K)]
+        self.c_p_H2 = 14304
+        self.c_p_O2 = 920
+        self.c_p_H2O = 4183
 
         # Number of cell amount on one stack.
         # TO MAKE IT POSSIBLE TO DEFINE A MAX. POWER OF THE ELECTROLYZER, THE NUMBER OF CELLS ARE ADJUSTED ACCORDINGLY.
@@ -91,19 +108,31 @@ class Electrolyzer (Component):
         # Tracking supporting points to calculate temperature later on.
         self.supporting_points = {}
 
+        # Save the two models to set constraints later.
+        self.model_h2 = None
+        self.model_th = None
+
     def conversion_fun_ely(self, ely_energy):
-        # Create a function that will give out the mass values for the energy values at the breakpoints.
+        # Create a function that will give out the mass values for the electric energy values at the breakpoints.
 
         # Check the index of this ely_energy entry.
         this_index = self.supporting_points['energy'].index(ely_energy)
         # Return the according hydrogen production value [kg].
         return self.supporting_points['h2_produced'][this_index]
 
-    def create_oemof_model(self, busses, _):
+    def conversion_fun_thermal(self, ely_energy):
+        # Create a function that will give out the thermal energy values for the electric energy values at the breakpoints.
+
+        # Check the index of this ely_energy entry.
+        this_index = self.supporting_points['energy'].index(ely_energy)
+        # Return the according hydrogen production value [kg].
+        return self.supporting_points['thermal_energy'][this_index]
+
+    def create_oemof_model(self, busses, model):
         # Get the non-linear behaviour.
         self.update_nonlinear_behaviour()
 
-        # Create the non-linear oemof component.
+        # First create the hydrogen producing oemof component
         electrolyzer = solph.custom.PiecewiseLinearTransformer(
             label=self.name,
             inputs={busses[self.bus_el]: solph.Flow(
@@ -113,7 +142,25 @@ class Electrolyzer (Component):
             in_breakpoints=self.supporting_points['energy'],
             conversion_function=self.conversion_fun_ely,
             pw_repn='CC')
-        return electrolyzer
+
+        # Then create the thermal oemof component.
+        electrolyzer_thermal = solph.custom.PiecewiseLinearTransformer(
+            label=self.name+'_thermal',
+            inputs={busses[self.bus_el]: solph.Flow(
+               nominal_value=self.energy_max,
+               variable_costs=0)},
+            outputs={busses[self.bus_th]: solph.Flow()},
+            in_breakpoints=self.supporting_points['energy'],
+            conversion_function=self.conversion_fun_thermal,
+            pw_repn='CC')
+
+        # Add the two components to the model.
+        model.add(electrolyzer, electrolyzer_thermal)
+
+        self.model_h2 = electrolyzer
+        self.model_th = electrolyzer_thermal
+
+        return None
 
     def update_nonlinear_behaviour(self):
         # Set up the breakpoints for the electrolyzer conversion of electricity to hydrogen.
@@ -122,6 +169,7 @@ class Electrolyzer (Component):
         bp_ely_energy = []
         bp_ely_h2 = []
         bp_ely_temp = []
+        bp_ely_thermal = []
         for i_supporting_point in range(n_supporting_point + 1):
             # Calculate the energy for this breakpoint [Wh].
             this_energy = i_supporting_point / n_supporting_point * self.energy_max
@@ -131,10 +179,15 @@ class Electrolyzer (Component):
             [this_mass, this_temp] = self.get_mass_and_temp(this_energy / 1000)
             bp_ely_h2.append(this_mass)
             bp_ely_temp.append(this_temp)
+            # Calculate the waste heat [Wh] with the energy, hydrogen produced and resulting temperature of this
+            # breakpoint at the current temperature.
+            this_waste_heat = self.get_waste_heat(this_energy / 1000, this_mass, this_temp) * 1000
+            bp_ely_thermal.append(this_waste_heat)
 
         self.supporting_points['temperature'] = bp_ely_temp
         self.supporting_points['h2_produced'] = bp_ely_h2
         self.supporting_points['energy'] = bp_ely_energy
+        self.supporting_points['thermal_energy'] = bp_ely_thermal
 
     def get_mass_and_temp(self, energy_used):
         # Calculate the mass produced and the resulting electrolyzer for a certain energy.
@@ -341,6 +394,44 @@ class Electrolyzer (Component):
 
         return voltage_reversible
 
+    def get_waste_heat(self, energy_used, h2_produced, new_ely_temp):
+        # source: Dieguez et al., 'Thermal Performance of a commercial alkaline water electrolyzer: Experimental study
+        # and mathematical modeling', Int. J. Hydrogen Energy, 2008
+        # parameters:
+        # energy_used [kWh], h2_produced [kg], new_ely_temp [K]
+        # return value:
+        # waste_heat [kWh]
+
+        # do not use cooling water until the aimed temperature is reached
+        # if new_ely_temp<(0.98*self.temp_max): # TO DO: statt temp_max würde temp_aim benötigt werden!
+
+        # calcualting the internal heat generation out of the relation Q = E_el*(1-eta_stack) with eta_stack = m_H2
+        # * HHV / E_el, eta_I (ac/dc conversion) is neglected for a first approximation
+        internal_heat_generation = energy_used - h2_produced * self.upp_heat_val / 3.6 # [kWh]
+        # heat losses modeled trough an overall convective-radiative heat transfer coeffiecient
+        heat_losses = (new_ely_temp - self.temp_min) / (self.resistance_to_heat_transfer * 1000) \
+                      * (self.interval_time / 60) # [kWh]
+        [sensible_heat, latent_heat] = self.sensible_and_latent_heats(h2_produced, new_ely_temp) # [kWh]
+        # amount of heat resulting in change of temperature
+        heat_change = self.lumped_thermal_capacitance * (new_ely_temp - self.temperature) / 3.6e6 # [kWh], 1J = 1/3.6e6 kWh
+        # heat that is removed through cooling
+        waste_heat = internal_heat_generation - heat_losses + sensible_heat - heat_change # [kWh]
+        return waste_heat
+
+    def sensible_and_latent_heats(self, mass_H2, new_ely_temp):
+        # mass of H2, O2 and H2O is related by the water decomposition stoichiometry and the mass balance
+        mass_O2 = mass_H2 * 0.5 * self.molar_mass_O2 / self.molarity
+        # as a first approximation mass_H2O_vapor is neglected in the mass balance, since condensers temperature and
+        # pressure are not known
+        mass_H2O = mass_H2 + mass_O2
+        # sensible heat removed from the system with the H2 and O2 streams, as well as the sensible heat required to
+        # warm the deionized water from room temperature to the stack operating temperature
+        sensible_heat = (mass_H2O * self.c_p_H2O * (self.temp_min - new_ely_temp) \
+                        - mass_H2 * self.c_p_H2 * (new_ely_temp - self.temp_min) \
+                        - mass_O2 * self.c_p_O2 * (new_ely_temp - self.temp_min)) / 3.6e6 # [kWh], 1J = 1/3.6e6 kWh
+        # latent heat is neglected since mass_H2O_vapor is neglected --> better approx. with LHV??
+        return [sensible_heat, 0]
+
     def update_states(self, results, sim_params):
         # Update the states of the electrolyzer
 
@@ -366,6 +457,20 @@ class Electrolyzer (Component):
         # Update the current temperature and the temperature state for this time step.
         self.temperature = this_temp
         self.states['temperature'][sim_params.i_interval] = this_temp
+
+    def update_constraints(self, busses, model_to_solve):
+        # Set a constraint so that the electric inflow of the hydrogen producing and the thermal part are always the same (which
+        # is necessary while the piecewise linear transformer cannot have two outputs yet and therefore the two parts
+        # need to be separate components).
+        def electrolyzer_ratio_rule(model, t):
+            # Inverter flow
+            expr = 0
+            expr += model.flow[busses[self.bus_el], self.model_th, t]
+            # force discharge to zero when grid available
+            expr += - model.flow[busses[self.bus_el], self.model_h2, t]
+            return (expr == 0)
+
+        model_to_solve.electrolyzer_flow_ratio_fix = po.Constraint(model_to_solve.TIMESTEPS, rule=electrolyzer_ratio_rule)
 
 
 


### PR DESCRIPTION
component_electrolyzer now includes a waste heat model (see get_waste_heat(..)), this requires two oemof models since the PiecewiseLinearTransformer can only have one output (see electrolyzer and electrolyzer_thermal in create_oemof_model(...))
Issues:
- might be useful to rename the component for having an electrolyzer with waste heat model and one without
- might be important to take the efficiency of th AC/DC converter into account
- heat losses are quite low, might require further investigation or upscaling of the parameter self.resistance_to_heat_transfer