### PR TITLE
Create component objects in a function

### DIFF
--- a/smooth/framework/functions/functions.py
+++ b/smooth/framework/functions/functions.py
@@ -1,6 +1,7 @@
 import os
 import importlib
 import pandas as pd
+import re
 
 
 def read_data_file(path, filename, csv_separator, column_title):
@@ -52,17 +53,15 @@ def create_component_obj(model, sim_params):
         # assign unique name
         this_comp['name'] = name
         # load the component class.
-        this_comp_name = this_comp['component']
+        this_comp_type = this_comp['component']
+        # Component type should consist of lower case letters, numbers and underscores
+        if re.fullmatch(r'[a-z0-9_]+', this_comp_type) is None:
+            raise ValueError('Invalid component type name "{}". '\
+                'Only lower case letters, numbers and underscores are allowed.'.format(this_comp_type))
         # Import the module of the component.
-        this_comp_module = importlib.import_module('smooth.components.component_' + this_comp_name)
-        # While class name is camel case, underscores has to be removed and letters after underscores have to be capital
-        class_name = ''
-        if this_comp_name.isupper():
-            class_name = this_comp_name
-        else:
-            this_comp_name_split = this_comp_name.split('_')
-            for this_comp_name_part in this_comp_name_split:
-                class_name += this_comp_name_part.capitalize()
+        this_comp_module = importlib.import_module('smooth.components.component_' + this_comp_type)
+        # Convert component type from snake_case to CamelCase to get class name
+        class_name = ''.join(x.capitalize() for x in this_comp_type.split('_'))
         # Load the class (which by convention has a name with a capital first letter and camel case).
         this_comp_class = getattr(this_comp_module, class_name)
         # Initialize the component.

--- a/smooth/framework/functions/functions.py
+++ b/smooth/framework/functions/functions.py
@@ -150,7 +150,7 @@ def extract_flow_per_bus(smooth_result, name_label_dict):
             # Replaces shorthand component names in the results with the official names for those listed.
             try:
                 component_result.name = name_label_dict[component_result.name]
-            except:
+            except KeyError:
                 print(component_result.name + ": is not defined in the label dict.")
 
             for this_bus in this_comp_flows:

--- a/smooth/framework/functions/plot_interactive_results.py
+++ b/smooth/framework/functions/plot_interactive_results.py
@@ -25,6 +25,7 @@ def plot_interactive_smooth_results(smooth_result, comp_label_dict=comp_dict, bu
             y_label = y_dict[this_bus]
         except KeyError:
             bus_label = 'bus: ' + this_bus
+            y_label = ''
 
         # Creates a new figure for plotting for this bus.
         figures[this_bus] = figure(plot_width=800, plot_height=600, title=bus_label, x_axis_label='Stunden des Jahres',

--- a/smooth/framework/functions/plot_interactive_results.py
+++ b/smooth/framework/functions/plot_interactive_results.py
@@ -23,7 +23,7 @@ def plot_interactive_smooth_results(smooth_result, comp_label_dict=comp_dict, bu
         try:
             bus_label = bus_dict[this_bus]
             y_label = y_dict[this_bus]
-        except:
+        except KeyError:
             bus_label = 'bus: ' + this_bus
 
         # Creates a new figure for plotting for this bus.

--- a/smooth/framework/functions/plot_results.py
+++ b/smooth/framework/functions/plot_results.py
@@ -16,7 +16,7 @@ def plot_smooth_results(smooth_result, comp_label_dict=comp_dict, bus_dict=bus_d
         try:
             plt.title(bus_dict[this_bus])
             plt.ylabel(y_dict[this_bus])
-        except:
+        except KeyError:
             plt.title('bus: ' + this_bus)
 
         plt.show()

--- a/smooth/framework/run_smooth.py
+++ b/smooth/framework/run_smooth.py
@@ -1,9 +1,9 @@
-import importlib
 from oemof import solph
 from oemof.outputlib import processing
 from smooth.framework.simulation_parameters import SimulationParameters as sp
 from smooth.framework.functions.debug import get_df_debug, show_debug
 from smooth.framework.exceptions import SolverNonOptimalError
+from smooth.framework.functions.functions import create_component_obj
 
 
 def run_smooth(model):
@@ -22,32 +22,7 @@ def run_smooth(model):
     sim_params = sp(model['sim_params'])
 
     # CREATE COMPONENT OBJECTS
-    components = []
-    for name, this_comp in model['components'].items():
-        # Add simulation parameters to the components so they can be used
-        this_comp['sim_params'] = sim_params
-        # assign unique name
-        this_comp['name'] = name
-        # load the component class.
-        this_comp_name = this_comp['component']
-        # Import the module of the component.
-        this_comp_module = importlib.import_module('smooth.components.component_' + this_comp_name)
-        # While class name is camel case, underscores has to be removed and letters after underscores have to be capital
-        class_name = ''
-        if this_comp_name.isupper():
-            class_name = this_comp_name
-        else:
-            this_comp_name_split = this_comp_name.split('_')
-            for this_comp_name_part in this_comp_name_split:
-                class_name += this_comp_name_part.capitalize()
-        # Load the class (which by convention has a name with a capital first letter and camel case).
-        this_comp_class = getattr(this_comp_module, class_name)
-        # Initialize the component.
-        this_comp_obj = this_comp_class(this_comp)
-        # Check if this component is valid.
-        this_comp_obj.check_validity()
-        # Add this component to the list containing all components.
-        components.append(this_comp_obj)
+    components = create_component_obj(model, sim_params)
 
     # There are no results yet.
     df_results = None


### PR DESCRIPTION
This PR is moving code from run_smooth to a separate function. Namely the code for the conversion of components description into components as smooth-objects.

(+ last two commit) More over smaller unrelated improvements on error catching and initialization.