### PR TITLE
Feature/save all smooth results

### DIFF
--- a/smooth/optimization/run_optimization.py
+++ b/smooth/optimization/run_optimization.py
@@ -157,7 +157,12 @@ def mutate(parent, attribute_variation):
     return child
 
 
-def fitness_function(index, individual, model, attribute_variation, dill_objectives, save_results=False):
+def fitness_function(
+        index, individual,
+        model,
+        attribute_variation,
+        dill_objectives,
+        save_results=False):
     # compute fitness for one individual
     # called async -> copies of individual and model given
     # program makes computer freeze when this is a class function?
@@ -270,7 +275,8 @@ class Optimization:
             if ind.fitness is None:  # not evaluated yet
                 pool.apply_async(
                     fitness_function,
-                    (idx, ind, self.model, self.attribute_variation, dill_objectives, self.SAVE_ALL_SMOOTH_RESULTS),
+                    (idx, ind, self.model, self.attribute_variation,
+                     dill_objectives, self.SAVE_ALL_SMOOTH_RESULTS),
                     callback=self.set_fitness,
                     error_callback=self.err_callback  # tb
                 )

--- a/smooth/optimization/run_optimization.py
+++ b/smooth/optimization/run_optimization.py
@@ -157,7 +157,7 @@ def mutate(parent, attribute_variation):
     return child
 
 
-def fitness_function(index, individual, model, attribute_variation, dill_objectives):
+def fitness_function(index, individual, model, attribute_variation, dill_objectives, save_results=False):
     # compute fitness for one individual
     # called async -> copies of individual and model given
     # program makes computer freeze when this is a class function?
@@ -168,8 +168,8 @@ def fitness_function(index, individual, model, attribute_variation, dill_objecti
     # Now that the model is updated according to the genes given by the GA, smooth can be run.
     try:
         smooth_result = run_smooth(model)[0]
-        # TODO: SAVE_ALL_SMOOTH_RESULTS can be given as arg if necessary
-        # individual.smooth_result = smooth_result if SAVE_ALL_SMOOTH_RESULTS else None
+        # SAVE_ALL_SMOOTH_RESULTS can be given as arg if necessary
+        individual.smooth_result = smooth_result if save_results else None
         # update fitness with given objective functions
         objectives = dill.loads(dill_objectives)
         individual.fitness = tuple(f(smooth_result) for f in objectives)
@@ -182,12 +182,12 @@ def fitness_function(index, individual, model, attribute_variation, dill_objecti
 
 class Optimization:
 
-    SAVE_ALL_SMOOTH_RESULTS = False  # ignored
-
     def __init__(self, iterable=(), **kwargs):
 
         # set defaults
         self.plot_progress = False
+        self.SAVE_ALL_SMOOTH_RESULTS = False
+
         # objective functions: tuple with lambdas
         # negative sign for minimizing
         # defaults to minimum of annual costs and emissions
@@ -270,7 +270,7 @@ class Optimization:
             if ind.fitness is None:  # not evaluated yet
                 pool.apply_async(
                     fitness_function,
-                    (idx, ind, self.model, self.attribute_variation, dill_objectives,),
+                    (idx, ind, self.model, self.attribute_variation, dill_objectives, self.SAVE_ALL_SMOOTH_RESULTS),
                     callback=self.set_fitness,
                     error_callback=self.err_callback  # tb
                 )
@@ -341,7 +341,7 @@ class Optimization:
 
                 # save pareto front
                 # values/fitness tuples for all non-dominated individuals
-                result = [(self.population[i].values, self.population[i].fitness) for i in FNDS[0]]
+                result = [self.population[i] for i in FNDS[0]]
 
                 # print info of current pareto front
                 print("The best front for Generation # {} / {} is".format(
@@ -353,8 +353,8 @@ class Optimization:
                 # show current pareto front in plot
                 if self.plot_progress:
                     # use abs(r[]) to display positive values
-                    f1_vals = [r[1][0] for r in result]
-                    f2_vals = [r[1][1] for r in result]
+                    f1_vals = [r.fitness[0] for r in result]
+                    f2_vals = [r.fitness[1] for r in result]
                     self.ax.clear()
                     self.ax.plot(f1_vals, f2_vals, '.b')
                     plt.title('Front for Generation #{}'.format(gen+1))
@@ -374,9 +374,9 @@ class Optimization:
         for i, attr in enumerate(self.attribute_variation):
             print(' {} - {}'.format(
                 attr.comp_name, attr.comp_attribute))
-        result.sort(key=lambda v: -v[1][0])
+        result.sort(key=lambda v: -v.fitness[0])
         for i, v in enumerate(result):
-            print(i, v[0], " -> ", dict(zip(self.objective_names, v[1])))
+            print(i, v.values, " -> ", dict(zip(self.objective_names, v.fitness)))
         print('+++++++++++++++++++++++++++++++++++++++++++\n')
 
         if self.plot_progress:


### PR DESCRIPTION
New optimization parameter SAVE_ALL_SMOOTH_RESULTS to save all smooth results for individuals. The result is saved in the 'smooth_result' property of each individual (alongside 'values'  for the configuration and 'fitness' for the objectives). If SAVE_ALL_SMOOTH_RESULTS is not set, the 'smooth_result' property is None.

To try it out, simply set 'SAVE_ALL_SMOOTH_PARAMS' in your ga_params to True. It defaults to False.

Fix #106 