### PR TITLE
Fix run_smooth_example

### DIFF
--- a/smooth/examples/run_smooth_example.py
+++ b/smooth/examples/run_smooth_example.py
@@ -4,7 +4,8 @@ from smooth import plot_smooth_results
 from smooth import print_smooth_results
 from smooth.examples.example_plotting_dicts import comp_dict_german
 
-# Run an example.
-smooth_result, status = run_smooth(mymodel)
-plot_smooth_results(smooth_result, comp_dict_german)
-print_smooth_results(smooth_result)
+if __name__ == '__main__':
+    # Run an example.
+    smooth_result, status = run_smooth(mymodel)
+    plot_smooth_results(smooth_result, comp_dict_german)
+    print_smooth_results(smooth_result)


### PR DESCRIPTION
Added ```__name__ == 'main'``` check to prevent accidental script execution (e.g. when generating docs).

Fix #116 