### PR TITLE
improved console feedback when aborting

### DIFF
--- a/smooth/optimization/run_optimization.py
+++ b/smooth/optimization/run_optimization.py
@@ -596,6 +596,9 @@ class Optimization:
                 try:
                     [parent1, parent2] = random.sample(self.population, 2)
                 except ValueError:
+                    print("Could not sample from {} parent{}. Not enough individuals left?".format(
+                        len(self.population)),
+                        '' if len(self.population) == 1 else 's')
                     break
 
                 # crossover and mutate parents
@@ -608,10 +611,13 @@ class Optimization:
                     children.append(child)
                     # block, so not in population again
                     self.evaluated[fingerprint] = None
+            else:
+                print("Warning: number of retries exceeded. {} new configurations generated.".format(
+                    len(children)))
 
             if len(children) == 0 and gen > 0:
                 # no new children could be generated
-                print("Search room exhausted. Aborting.")
+                print("Aborting.")
                 break
 
             # New population generated (parents + children)

--- a/smooth/optimization/run_optimization.py
+++ b/smooth/optimization/run_optimization.py
@@ -597,8 +597,8 @@ class Optimization:
                     [parent1, parent2] = random.sample(self.population, 2)
                 except ValueError:
                     print("Could not sample from {} parent{}. Not enough individuals left?".format(
-                        len(self.population)),
-                        '' if len(self.population) == 1 else 's')
+                        len(self.population),
+                        '' if len(self.population) == 1 else 's'))
                     break
 
                 # crossover and mutate parents
@@ -612,7 +612,8 @@ class Optimization:
                     # block, so not in population again
                     self.evaluated[fingerprint] = None
             else:
-                print("Warning: number of retries exceeded. {} new configurations generated.".format(
+                print("Warning: number of retries exceeded. \
+                {} new configurations generated.".format(
                     len(children)))
 
             if len(children) == 0 and gen > 0:


### PR DESCRIPTION
When exceeding retries to generate new children, the number of newly generated individuals get printed to console.
Also, when generating the first child generation, not enough parents may have been left in the population (need at least two for sampling). This is now printed to console as well for better debugging.

Fix #136 