### PR TITLE
changed population creation in gradient ascent

### DIFF
--- a/smooth/optimization/run_optimization.py
+++ b/smooth/optimization/run_optimization.py
@@ -925,12 +925,14 @@ class Optimization:
                 self.compute_fitness()
 
                 # check new dominance of parent and children
+                # default: no improvement -> stop ascent of this attribute
                 new_step = [0] * len(step)
                 for idx, child in enumerate(self.population):
                     parent_idx = reference[idx]
                     parent = new_result[parent_idx]
                     if child.dominates(parent):
                         # domination continues: save child, keep base step
+                        # this ensures a new generation
                         new_result[parent_idx] = child
                         new_step[parent_idx] = step[parent_idx]
 


### PR DESCRIPTION
Fix #170 

During gradient ascent, new children are only created for parents that  still have improvement potential. Any empty slots in the population short of n_cores are filled up by the same children with multiples in their step size. This effectively checks parents multiple steps ahead during the same generation, instead of only one step ahead.