### PR TITLE
fix time axis in plot_smooth_results

### DIFF
--- a/smooth/framework/functions/plot_results.py
+++ b/smooth/framework/functions/plot_results.py
@@ -1,4 +1,5 @@
 from matplotlib import pyplot as plt
+from smooth.framework.simulation_parameters import SimulationParameters
 from smooth.framework.functions.functions import extract_flow_per_bus
 from smooth.examples.example_plotting_dicts import comp_dict_german, bus_dict_german, y_dict_german
 
@@ -8,10 +9,18 @@ def plot_smooth_results(smooth_result, comp_label_dict=comp_dict_german,
     # Extract dict containing the busses that will be plotted.
     busses_to_plot = extract_flow_per_bus(smooth_result, comp_label_dict)
 
+    # get first sim_params from smooth_result component for interval_time
+    sim_params = next(
+        (comp.sim_params for comp in smooth_result if hasattr(comp, 'sim_params')),
+        SimulationParameters({})  # default values
+    )
+
     # Plot each bus in a new window.
     for this_bus in busses_to_plot:
         for this_component, this_flow in busses_to_plot[this_bus].items():
-            plt.plot(this_flow, label=str(this_component))
+            # get time axis (in hours, interval_time is in minutes)
+            timeseries = [sim_params.interval_time/60 * t for t in range(len(this_flow))]
+            plt.plot(timeseries, this_flow, label=str(this_component))
         plt.legend()
         plt.xlabel('Stunden des Jahres')
         try:


### PR DESCRIPTION
Interval time was set statically to 60 minutes. This simulation parameter is now retrieved from the smooth result and the time axis scaled accordingly.

See also #159 