### PR TITLE
Feature free intervaltime subbranch

### DIFF
--- a/smooth/components/component.py
+++ b/smooth/components/component.py
@@ -127,12 +127,12 @@ class Component:
         if self.variable_costs is not None:
             this_dependency_value = self.flows[self.dependency_flow_costs][sim_params.i_interval]
             self.results['variable_costs'][sim_params.i_interval] = this_dependency_value * \
-                self.variable_costs
+                self.variable_costs * sim_params.interval_time/60
         # Update the artificial costs for this time step [EUR].
         if self.artificial_costs is not None:
             this_dependency_value = self.flows[self.dependency_flow_costs][sim_params.i_interval]
             self.results['art_costs'][sim_params.i_interval] = this_dependency_value * \
-                self.artificial_costs
+                self.artificial_costs * sim_params.interval_time/60
 
     def update_var_emissions(self, results, sim_params):
         # Track the emissions of a component for each time step.
@@ -152,7 +152,7 @@ class Component:
             this_dependency_value = \
                 self.flows[self.dependency_flow_emissions][sim_params.i_interval]
             self.results['variable_emissions'][sim_params.i_interval] = \
-                this_dependency_value * self.variable_emissions
+                this_dependency_value * self.variable_emissions * sim_params.interval_time/60
 
     # ------ ADD COSTS AND ARTIFICIAL COSTS TO A PARAMETER IF THEY ARE NOT NONE ------
 

--- a/smooth/components/component_battery.py
+++ b/smooth/components/component_battery.py
@@ -97,7 +97,7 @@ class Battery(Component):
 
         # ToDo: c_rate depending on the soc
 
-        # Max. chargeable or dischargeable power [W] goinge in from the bus
+        # Max. chargeable or dischargeable power [W] going in from the bus
         # due to c_rate depending on the soc. To ensure that the battery can
         # be fully charged in one timestep, the nominal value of the input-flow
         # needs to be higher than what's actually going into the battery.

--- a/smooth/components/component_battery.py
+++ b/smooth/components/component_battery.py
@@ -97,29 +97,20 @@ class Battery(Component):
 
         # ToDo: c_rate depending on the soc
 
-        # Max. chargeable or dischargeable energy [Wh] goinge in from the bus
+        # Max. chargeable or dischargeable power [W] goinge in from the bus
         # due to c_rate depending on the soc. To ensure that the battery can
         # be fully charged in one timestep, the nominal value of the input-flow
         # needs to be higher than what's actually going into the battery.
         # Therefore we need to divide by the efficiency_charge.  Due to the
         # inflow_conversion_factor (in "create oemof model") the battery will
         # then receive right amount.
-        # Todo: What about the interval time specific parametrisation here? necessary?
+
         self.e_in_max = min(self.c_rate_charge * self.battery_capacity,
                             (self.battery_capacity - self.soc * self.battery_capacity)
                             * 60/self.sim_params.interval_time) / self.efficiency_charge
-        # self.e_in_max = min(
-        #     self.c_rate_charge * self.battery_capacity * self.sim_params.interval_time / 60,
-        #     self.battery_capacity - self.soc * self.battery_capacity) / \
-        #                 self.efficiency_charge
-
         self.e_out_max = min(
             self.c_rate_discharge * self.battery_capacity,
             (self.soc * self.battery_capacity) * 60/self.sim_params.interval_time)
-
-        # self.e_out_max = min(
-        #     self.c_rate_discharge * self.battery_capacity * self.sim_params.interval_time / 60,
-        #     self.soc * self.battery_capacity)
 
     def create_oemof_model(self, busses, _):
         """ Create oemof model """

--- a/smooth/components/component_battery.py
+++ b/smooth/components/component_battery.py
@@ -104,6 +104,7 @@ class Battery(Component):
         # Therefore we need to divide by the efficiency_charge.  Due to the
         # inflow_conversion_factor (in "create oemof model") the battery will
         # then receive right amount.
+        # Todo: What about th einterval time specific parametrisation here? necessary?
         self.e_in_max = min(
             self.c_rate_charge * self.battery_capacity * self.sim_params.interval_time / 60,
             self.battery_capacity - self.soc * self.battery_capacity) / \

--- a/smooth/components/component_battery.py
+++ b/smooth/components/component_battery.py
@@ -104,14 +104,22 @@ class Battery(Component):
         # Therefore we need to divide by the efficiency_charge.  Due to the
         # inflow_conversion_factor (in "create oemof model") the battery will
         # then receive right amount.
-        # Todo: What about th einterval time specific parametrisation here? necessary?
-        self.e_in_max = min(
-            self.c_rate_charge * self.battery_capacity * self.sim_params.interval_time / 60,
-            self.battery_capacity - self.soc * self.battery_capacity) / \
-            self.efficiency_charge
+        # Todo: What about the interval time specific parametrisation here? necessary?
+        self.e_in_max = min(self.c_rate_charge * self.battery_capacity,
+                            (self.battery_capacity - self.soc * self.battery_capacity)
+                            * 60/self.sim_params.interval_time) / self.efficiency_charge
+        # self.e_in_max = min(
+        #     self.c_rate_charge * self.battery_capacity * self.sim_params.interval_time / 60,
+        #     self.battery_capacity - self.soc * self.battery_capacity) / \
+        #                 self.efficiency_charge
+
         self.e_out_max = min(
-            self.c_rate_discharge * self.battery_capacity * self.sim_params.interval_time / 60,
-            self.soc * self.battery_capacity)
+            self.c_rate_discharge * self.battery_capacity,
+            (self.soc * self.battery_capacity) * 60/self.sim_params.interval_time)
+
+        # self.e_out_max = min(
+        #     self.c_rate_discharge * self.battery_capacity * self.sim_params.interval_time / 60,
+        #     self.soc * self.battery_capacity)
 
     def create_oemof_model(self, busses, _):
         """ Create oemof model """

--- a/smooth/components/component_battery.py
+++ b/smooth/components/component_battery.py
@@ -69,8 +69,9 @@ class Battery(Component):
         # State of charge [%]
         self.soc = self.soc_init
 
-        # Initialize max. chargeable or dischargeable energy [Wh].
-        self.e_in_max = None
+        # Initialize max. chargeable or dischargeable power [W].
+        self.p_in_max = None
+        self.p_out_max = None
 
         # Adjust loss rate to chosen timestep [%/timestep].
         self.loss_rate = (self.loss_rate / 24) * (self.sim_params.interval_time / 60)
@@ -105,10 +106,10 @@ class Battery(Component):
         # inflow_conversion_factor (in "create oemof model") the battery will
         # then receive right amount.
 
-        self.e_in_max = min(self.c_rate_charge * self.battery_capacity,
+        self.p_in_max = min(self.c_rate_charge * self.battery_capacity,
                             (self.battery_capacity - self.soc * self.battery_capacity)
                             * 60/self.sim_params.interval_time) / self.efficiency_charge
-        self.e_out_max = min(
+        self.p_out_max = min(
             self.c_rate_discharge * self.battery_capacity,
             (self.soc * self.battery_capacity) * 60/self.sim_params.interval_time)
 
@@ -117,10 +118,10 @@ class Battery(Component):
         storage = solph.components.GenericStorage(
             label=self.name,
             inputs={busses[self.bus_in_and_out]: solph.Flow(
-                    nominal_value=self.e_in_max, variable_costs=self.current_vac[0])
+                    nominal_value=self.p_in_max, variable_costs=self.current_vac[0])
                     },
             outputs={busses[self.bus_in_and_out]: solph.Flow(
-                nominal_value=self.e_out_max, variable_costs=self.current_vac[1])
+                nominal_value=self.p_out_max, variable_costs=self.current_vac[1])
             },
             loss_rate=self.loss_rate,
             initial_storage_level=self.soc,

--- a/smooth/components/component_sink.py
+++ b/smooth/components/component_sink.py
@@ -13,14 +13,15 @@ class Sink(Component):
         # ------------------- PARAMETERS -------------------
         self.name = 'Grid_default_name'
 
-        # Maximum input per timestep of commodity:
-        # e.g. for the electricity grid [Wh], thermal grid [Wh], CH4 grid [Wh]
+        # Maximum input per hour:
+        # e.g. for the electricity grid [W], thermal grid [W], CH4 grid [kg/h]
         self.input_max = 800000000
 
         self.bus_in = None
 
         # ------------------- UPDATE PARAMETER DEFAULT VALUES -------------------
         self.set_parameters(params)
+        self.input_max = self.input_max * self.sim_params.interval_time / 60
 
         # ------------------- COSTS -------------------
         # Define the costs for the commodities (negative means earning money)

--- a/smooth/components/component_sink.py
+++ b/smooth/components/component_sink.py
@@ -21,7 +21,7 @@ class Sink(Component):
 
         # ------------------- UPDATE PARAMETER DEFAULT VALUES -------------------
         self.set_parameters(params)
-        self.input_max = self.input_max * self.sim_params.interval_time / 60
+        # self.input_max = self.input_max * self.sim_params.interval_time / 60
 
         # ------------------- COSTS -------------------
         # Define the costs for the commodities (negative means earning money)

--- a/smooth/components/component_sink.py
+++ b/smooth/components/component_sink.py
@@ -21,7 +21,6 @@ class Sink(Component):
 
         # ------------------- UPDATE PARAMETER DEFAULT VALUES -------------------
         self.set_parameters(params)
-        # self.input_max = self.input_max * self.sim_params.interval_time / 60
 
         # ------------------- COSTS -------------------
         # Define the costs for the commodities (negative means earning money)

--- a/smooth/components/component_supply.py
+++ b/smooth/components/component_supply.py
@@ -35,7 +35,7 @@ class Supply (Component):
 
         # ------------------- UPDATE PARAMETER DEFAULT VALUES -------------------
         self.set_parameters(params)
-        self.output_max = self.output_max * self.sim_params.interval_time / 60
+        # self.output_max = self.output_max * self.sim_params.interval_time / 60
 
         # ------------------- INTERNAL VALUES -------------------
         # The current artificial cost value e.g. [EUR/Wh], [EUR/kg].

--- a/smooth/components/component_supply.py
+++ b/smooth/components/component_supply.py
@@ -35,7 +35,6 @@ class Supply (Component):
 
         # ------------------- UPDATE PARAMETER DEFAULT VALUES -------------------
         self.set_parameters(params)
-        # self.output_max = self.output_max * self.sim_params.interval_time / 60
 
         # ------------------- INTERNAL VALUES -------------------
         # The current artificial cost value e.g. [EUR/Wh], [EUR/kg].

--- a/smooth/components/component_supply.py
+++ b/smooth/components/component_supply.py
@@ -14,8 +14,8 @@ class Supply (Component):
 
         # ------------------- PARAMETERS -------------------
         self.name = 'Grid_default_name'
-        # Maximum output per timestep of commodity:
-        # e.g. for the electricity grid [Wh], thermal grid [Wh], CH4 grid [kg/h]
+        # Maximum output per hour:
+        # e.g. for the electricity grid [W], thermal grid [W], CH4 grid [kg/h]
         self.output_max = 8000000
 
         self.bus_out = None
@@ -35,6 +35,7 @@ class Supply (Component):
 
         # ------------------- UPDATE PARAMETER DEFAULT VALUES -------------------
         self.set_parameters(params)
+        self.output_max = self.output_max * self.sim_params.interval_time / 60
 
         # ------------------- INTERNAL VALUES -------------------
         # The current artificial cost value e.g. [EUR/Wh], [EUR/kg].

--- a/smooth/components/component_var_battery.py
+++ b/smooth/components/component_var_battery.py
@@ -1,0 +1,224 @@
+import oemof.solph as solph
+from .component import Component
+from oemof.outputlib import views
+
+
+class VarBattery(Component):
+    """ Stationary battery is created through this class """
+
+    def __init__(self, params):
+
+        # Call the init function of the mother class.
+        Component.__init__(self)
+
+        # ------------------- PARAMETERS -------------------
+        self.name = "Battery_default_name"
+
+        # Define the electric bus the battery is connected to.
+        self.bus_in_and_out = None
+
+        self.battery_type = 1
+
+        # Battery capacity (assuming all the capacity can be used) [Wh].
+        # Battery type 1: Li_battery 1 - 50 kWh
+        self.battery_capacity_bt1 = 10 * 1e3
+        # Battery type 2: Li_battery 50 - 1000 kWh
+        self.battery_capacity_bt2 = 100 * 1e3
+        # Battery type 3: Li_battery > 1000 kWh
+        self.battery_capacity_bt3 = 1 * 1e6
+        # Battery type 4: ????
+        self.battery_capacity_bt4 = 1
+        # Battery type 5: ????
+        self.battery_capacity_bt5 = 1
+        # Battery type 6: ????
+        self.battery_capacity_bt6 = 1
+
+        # Capex for each battery type
+        self.capex_bt1 = {
+            'key': ['poly'],
+            'fitting_value': [[0, 2109.62368 / 1e3, -147.52325 / 1e6, 6.97016 / 1e9, -0.13996 / 1e12, 0.00102 / 1e15]],
+            'dependant_value': ['battery_capacity']},
+
+        self.capex_bt2 = {
+             'key': ['poly'],
+             'fitting_value': [[0, 1000.2 / 1e3, -0.4983 / 1e6]],
+             'dependant_value': ['battery_capacity']},
+
+        self.capex_bt3 = {
+             'key': ['poly', 'spec'],
+             'fitting_value': [[0.353, 0.149], 'cost'],  # für 2020
+             # 'fitting_value': [[0.289, 0.126], 'cost'],  # für 2025
+             # 'fitting_value': [[0.251, 0.114], 'cost'],  # für 2030
+             # 'fitting_value': [[0.206, 0.0971], 'cost'],  # für 2035
+             # 'fitting_value': [[0.179, 0.0857], 'cost'],  # für 2040
+             'dependant_value': ['c_rate_charge', 'battery_capacity']},
+
+        self.capex_bt4 = {
+            'key': ['poly'],
+            'fitting_value': [[500000, 0.02]],
+            'dependant_value': ['output_max']}
+
+        self.capex_bt5 = {
+            'key': ['poly'],
+            'fitting_value': [[1000000, 0.01]],
+            'dependant_value': ['output_max']}
+
+        self.capex_bt6 = {
+            'key': ['poly'],
+            'fitting_value': [[10000000, 0.01]],
+            'dependant_value': ['output_max']}
+
+        # Initial State of charge [-].
+        self.soc_init = 0.5
+        # ToDo: set default value for efficiency
+        # Efficiency charge [-].
+        self.efficiency_charge = 0.95
+        # Efficiency discharge [-].
+        self.efficiency_discharge = 0.95
+        # ToDo: set default value loss rate
+        # Loss rate [%/day]
+        self.loss_rate = 0
+        # ToDo: set default value for c-rate
+        # C-Rate [-/h].
+        self.c_rate = 1
+        # self.c_rate_charge = 1
+        # self.c_rate_discharge = 1
+        # ToDo: set default value for depth of discharge
+        # Depth of discharge [-].
+        self.dod = 0
+        # ToDo: set default value life time. Per cycle or time
+        # Life time [a].
+        self.life_time = 20
+        # ToDo: set default value for degradation over lifetime
+        # Degradation over lifetime [%]
+        # self.degradation =
+
+        # ------------------- PARAMETERS (VARIABLE ARTIFICIAL COSTS - VAC) -------------------
+        # Normal var. art. costs for charging (in) and discharging (out) the
+        # battery [EUR/Wh]. vac_out should be set to a minimal value to ensure,
+        # that the supply for the demand is first satisfied by the renewables
+        # (costs are 0), second satisfied by the battery and last by the grid.
+        self.vac_in = None
+        self.vac_out = None
+        # If a soc level is set as wanted, the vac_low costs apply if the
+        # capacity is below that level [Wh].
+        self.soc_wanted = None
+        # Var. art. costs that apply if the capacity level is below the wanted
+        # capacity level [EUR/Wh].
+        self.vac_low_in = 0
+        self.vac_low_out = 0
+
+        # ------------------- UPDATE PARAMETER DEFAULT VALUES -------------------
+        self.set_parameters(params)
+        # Raise an error if the initial state of charge [%] is set below depth of discharge [%].
+        if self.soc_init < self.dod:
+            raise ValueError(
+                'Initial state of charge is set below depth of discharge! '
+                'Please adjust soc_init or dod.')
+        if self.battery_type == 1:
+            self.battery_capacity = self.battery_capacity_bt1
+            self.capex = self.capex_bt1
+        elif self.battery_type == 2:
+            self.battery_capacity = self.battery_capacity_bt2
+            self.capex = self.capex_bt2
+        elif self.battery_type == 3:
+            self.battery_capacity = self.battery_capacity_bt3
+            self.capex = self.capex_bt3
+        elif self.battery_type == 4:
+            self.battery_capacity = self.battery_capacity_bt4
+            self.capex = self.capex_bt4
+        elif self.battery_type == 5:
+            self.battery_capacity = self.battery_capacity_bt5
+            self.capex = self.capex_bt5
+        elif self.battery_type == 6:
+            self.battery_capacity = self.battery_capacity_bt6
+            self.capex = self.capex_bt6
+
+        self.c_rate_discharge = self.c_rate
+        self.c_rate_charge = self.c_rate
+        # This value can be used as faktor in capex to add an insignificant cost for higher c-rates.
+        # The optimization then strives towards a low c-rate, even for price models which are independet of the c-rate
+        self.c_rate_insig_cost = 1 + self.c_rate * 0.00001
+
+        # ------------------- STATES -------------------
+        # State of charge [%]
+        self.soc = self.soc_init
+
+        # Initialize max. chargeable or dischargeable power [W].
+        self.p_in_max = None
+        self.p_out_max = None
+
+        # Adjust loss rate to chosen timestep [%/timestep].
+        self.loss_rate = (self.loss_rate / 24) * (self.sim_params.interval_time / 60)
+
+        # ------------------- VARIABLE ARTIFICIAL COSTS -------------------
+        # Store the current artificial costs for input and output [EUR/Wh].
+        self.current_vac = [0, 0]
+
+    def prepare_simulation(self, components):
+        """ Prepare simulation """
+        # Set the var. art. costs.
+        vac_in = self.vac_in
+        vac_out = self.vac_out
+
+        if self.soc_wanted is not None and self.soc < self.soc_wanted:
+            # If a wanted storage level is set and the storage level drops
+            # below that wanted level, the low VAC apply.
+            vac_in = self.vac_low_in
+            vac_out = self.vac_low_out
+
+        self.current_vac = [vac_in, vac_out]
+
+        # ToDo: efficiency depending on the soc
+
+        # ToDo: c_rate depending on the soc
+
+        # Max. chargeable or dischargeable power [W] going in from the bus
+        # due to c_rate depending on the soc. To ensure that the battery can
+        # be fully charged in one timestep, the nominal value of the input-flow
+        # needs to be higher than what's actually going into the battery.
+        # Therefore we need to divide by the efficiency_charge.  Due to the
+        # inflow_conversion_factor (in "create oemof model") the battery will
+        # then receive right amount.
+
+        self.p_in_max = min(self.c_rate_charge * self.battery_capacity,
+                            (self.battery_capacity - self.soc * self.battery_capacity)
+                            * 60/self.sim_params.interval_time) / self.efficiency_charge
+        self.p_out_max = min(
+            self.c_rate_discharge * self.battery_capacity,
+            (self.soc * self.battery_capacity) * 60/self.sim_params.interval_time)
+
+    def create_oemof_model(self, busses, _):
+        """ Create oemof model """
+        storage = solph.components.GenericStorage(
+            label=self.name,
+            inputs={busses[self.bus_in_and_out]: solph.Flow(
+                    nominal_value=self.p_in_max, variable_costs=self.current_vac[0])
+                    },
+            outputs={busses[self.bus_in_and_out]: solph.Flow(
+                nominal_value=self.p_out_max, variable_costs=self.current_vac[1])
+            },
+            loss_rate=self.loss_rate,
+            initial_storage_level=self.soc,
+            nominal_storage_capacity=self.battery_capacity,
+            min_storage_level=self.dod,
+            inflow_conversion_factor=self.efficiency_charge,
+            outflow_conversion_factor=self.efficiency_discharge,
+            balanced=False,
+        )
+        return storage
+
+    def update_states(self, results, sim_params):
+        """ Update states """
+        data_storage = views.node(results, self.name)
+        df_storage = data_storage["sequences"]
+
+        # Loop Through the data frame values and update states accordingly.
+        for i_result in df_storage:
+            if i_result[1] == "capacity":
+                if "soc" not in self.states:
+                    # Initialize a.n array that tracks the state SoC
+                    self.states["soc"] = [None] * sim_params.n_intervals
+                # Check if this result is the state of charge.
+                self.soc = df_storage[i_result][0] / self.battery_capacity
+                self.states["soc"][sim_params.i_interval] = self.soc

--- a/smooth/components/component_var_battery.py
+++ b/smooth/components/component_var_battery.py
@@ -36,7 +36,8 @@ class VarBattery(Component):
         # Capex for each battery type
         self.capex_bt1 = {
             'key': ['poly'],
-            'fitting_value': [[0, 2109.62368 / 1e3, -147.52325 / 1e6, 6.97016 / 1e9, -0.13996 / 1e12, 0.00102 / 1e15]],
+            'fitting_value': [[0, 2109.62368 / 1e3, -147.52325 / 1e6, 6.97016 / 1e9,
+                               -0.13996 / 1e12, 0.00102 / 1e15]],
             'dependant_value': ['battery_capacity']},
 
         self.capex_bt2 = {
@@ -137,7 +138,8 @@ class VarBattery(Component):
         self.c_rate_discharge = self.c_rate
         self.c_rate_charge = self.c_rate
         # This value can be used as faktor in capex to add an insignificant cost for higher c-rates.
-        # The optimization then strives towards a low c-rate, even for price models which are independet of the c-rate
+        # The optimization then strives towards a low c-rate,
+        # even for price models which are independet of the c-rate
         self.c_rate_insig_cost = 1 + self.c_rate * 0.00001
 
         # ------------------- STATES -------------------

--- a/smooth/components/component_var_grid.py
+++ b/smooth/components/component_var_grid.py
@@ -81,27 +81,21 @@ class VarGrid(Component):
         self.set_parameters(params)
         # adjust to set level of grid and given timestep
         if self.grid_level == 1:
-            # self.output_max = self.grid_l1_output_max * self.sim_params.interval_time / 60
             self.output_max = self.grid_l1_output_max
             self.capex = self.capex_l1
         elif self.grid_level == 2:
-            # self.output_max = self.grid_l2_output_max * self.sim_params.interval_time / 60
             self.output_max = self.grid_l2_output_max
             self.capex = self.capex_l2
         elif self.grid_level == 3:
-            # self.output_max = self.grid_l3_output_max * self.sim_params.interval_time / 60
             self.output_max = self.grid_l3_output_max
             self.capex = self.capex_l3
         elif self.grid_level == 4:
-            # self.output_max = self.grid_l4_output_max * self.sim_params.interval_time / 60
             self.output_max = self.grid_l4_output_max
             self.capex = self.capex_l4
         elif self.grid_level == 5:
-            # self.output_max = self.grid_l5_output_max * self.sim_params.interval_time / 60
             self.output_max = self.grid_l5_output_max
             self.capex = self.capex_l5
         elif self.grid_level == 6:
-            # self.output_max = self.grid_l6_output_max * self.sim_params.interval_time / 60
             self.output_max = self.grid_l6_output_max
             self.capex = self.capex_l6
 

--- a/smooth/components/component_var_grid.py
+++ b/smooth/components/component_var_grid.py
@@ -1,0 +1,125 @@
+import oemof.solph as solph
+from .component import Component
+
+
+class VarGrid(Component):
+    """ An electric grid with different connection levels can be created through this class """
+
+    def __init__(self, params):
+
+        # Call the init function of the mother class.
+        Component.__init__(self)
+
+        # ------------------- PARAMETERS -------------------
+        self.name = 'Variable_Grid_default_name'
+
+        # Gridlevels [1,2,3,4,5,6] describe the grid connection:
+        # [1] house connection, [2] lov voltage grid, [3] lov voltage local network station
+        # [4] medium voltage grid, [5] medium voltage transformer station, [6] High Voltage
+        # These can be associated with different output_max and capex for each level
+        # default values for output_max from https://www.stromnetz-hamburg.de/netzanschluss/netzanschlussanfrage/
+
+        self.grid_level = 1
+
+        # Maximum power output in each grid level
+        # e.g. for the electricity grid [W]
+        self.grid_l1_output_max = 30 * 1e3
+        self.grid_l2_output_max = 100 * 1e3
+        self.grid_l3_output_max = 540 * 1e3
+        self.grid_l4_output_max = 1.5 * 1e6
+        self.grid_l5_output_max = 12 * 1e6
+        self.grid_l6_output_max = 100 * 1e6
+
+        # Capex for each grid level (e.g grid connection costs)
+        self.capex_l1 = {
+            'key': ['poly'],
+            'fitting_value': [[700, 0.018]],
+            'dependant_value': ['output_max']}
+
+        self.capex_l2 = {
+            'key': ['poly'],
+            'fitting_value': [[700, 0.018]],
+            'dependant_value': ['output_max']}
+
+        self.capex_l3 = {
+            'key': ['poly'],
+            'fitting_value': [[120000, 0.02]],
+            'dependant_value': ['output_max']}
+
+        self.capex_l4 = {
+            'key': ['poly'],
+            'fitting_value': [[500000, 0.02]],
+            'dependant_value': ['output_max']}
+
+        self.capex_l5 = {
+            'key': ['poly'],
+            'fitting_value': [[1000000, 0.01]],
+            'dependant_value': ['output_max']}
+
+        self.capex_l6 = {
+            'key': ['poly'],
+            'fitting_value': [[10000000, 0.01]],
+            'dependant_value': ['output_max']}
+
+        self.bus_out = None
+
+        # ------------- PARAMETERS ARTIFICIAL COSTS FOREIGN STATE --------------
+        # The artificial costs for supplying electricity can be dependant on a
+        # foreign state, like a storage SoC. Therefore the name and the state
+        # name of that foreign entity have to be defined as well as the threshold
+        # level, under which the low level costs are used. Above the threshold,
+        # the high level artificial costs are used.
+
+        # Define the threshold value for the artificial costs.
+        self.fs_threshold = None
+        # Define the low and the high art. cost value e.g. [EUR/Wh], [EUR/kg]
+        self.fs_low_art_cost = None
+        self.fs_high_art_cost = None
+
+        # ------------------- UPDATE PARAMETER DEFAULT VALUES -------------------
+        self.set_parameters(params)
+        # adjust to set level of grid and given timestep
+        if self.grid_level == 1:
+            self.output_max = self.grid_l1_output_max * self.sim_params.interval_time / 60
+            self.capex = self.capex_l1
+        elif self.grid_level == 2:
+            self.output_max = self.grid_l2_output_max * self.sim_params.interval_time / 60
+            self.capex = self.capex_l2
+        elif self.grid_level == 3:
+            self.output_max = self.grid_l3_output_max * self.sim_params.interval_time / 60
+            self.capex = self.capex_l3
+        elif self.grid_level == 4:
+            self.output_max = self.grid_l4_output_max * self.sim_params.interval_time / 60
+            self.capex = self.capex_l4
+        elif self.grid_level == 5:
+            self.output_max = self.grid_l5_output_max * self.sim_params.interval_time / 60
+            self.capex = self.capex_l5
+        elif self.grid_level == 6:
+            self.output_max = self.grid_l6_output_max * self.sim_params.interval_time / 60
+            self.capex = self.capex_l6
+
+        # ------------------- INTERNAL VALUES -------------------
+        # The current artificial cost value e.g. [EUR/Wh], [EUR/kg].
+        self.current_ac = 0
+
+    def prepare_simulation(self, components):
+        # Update the artificial costs for this time step (dependant on foreign states).
+        if self.fs_component_name is not None:
+            foreign_state_value = self.get_foreign_state_value(components)
+            if foreign_state_value < self.fs_threshold:
+                self.artificial_costs = self.fs_low_art_cost
+            else:
+                self.artificial_costs = self.fs_high_art_cost
+
+        # Set the total costs for the commodity this time step
+        # (costs + art.  costs) e.g. [EUR/Wh], [EUR/kg].
+        self.current_ac = self.get_costs_and_art_costs()
+
+    def create_oemof_model(self, busses, _):
+        from_grid = solph.Source(
+            label=self.name,
+            outputs={busses[self.bus_out]: solph.Flow(
+                nominal_value=self.output_max,
+                variable_costs=self.current_ac
+            )})
+        return from_grid

--- a/smooth/components/component_var_grid.py
+++ b/smooth/components/component_var_grid.py
@@ -81,22 +81,28 @@ class VarGrid(Component):
         self.set_parameters(params)
         # adjust to set level of grid and given timestep
         if self.grid_level == 1:
-            self.output_max = self.grid_l1_output_max * self.sim_params.interval_time / 60
+            # self.output_max = self.grid_l1_output_max * self.sim_params.interval_time / 60
+            self.output_max = self.grid_l1_output_max
             self.capex = self.capex_l1
         elif self.grid_level == 2:
-            self.output_max = self.grid_l2_output_max * self.sim_params.interval_time / 60
+            # self.output_max = self.grid_l2_output_max * self.sim_params.interval_time / 60
+            self.output_max = self.grid_l2_output_max
             self.capex = self.capex_l2
         elif self.grid_level == 3:
-            self.output_max = self.grid_l3_output_max * self.sim_params.interval_time / 60
+            # self.output_max = self.grid_l3_output_max * self.sim_params.interval_time / 60
+            self.output_max = self.grid_l3_output_max
             self.capex = self.capex_l3
         elif self.grid_level == 4:
-            self.output_max = self.grid_l4_output_max * self.sim_params.interval_time / 60
+            # self.output_max = self.grid_l4_output_max * self.sim_params.interval_time / 60
+            self.output_max = self.grid_l4_output_max
             self.capex = self.capex_l4
         elif self.grid_level == 5:
-            self.output_max = self.grid_l5_output_max * self.sim_params.interval_time / 60
+            # self.output_max = self.grid_l5_output_max * self.sim_params.interval_time / 60
+            self.output_max = self.grid_l5_output_max
             self.capex = self.capex_l5
         elif self.grid_level == 6:
-            self.output_max = self.grid_l6_output_max * self.sim_params.interval_time / 60
+            # self.output_max = self.grid_l6_output_max * self.sim_params.interval_time / 60
+            self.output_max = self.grid_l6_output_max
             self.capex = self.capex_l6
 
         # ------------------- INTERNAL VALUES -------------------

--- a/smooth/components/component_var_grid.py
+++ b/smooth/components/component_var_grid.py
@@ -17,7 +17,8 @@ class VarGrid(Component):
         # [1] house connection, [2] lov voltage grid, [3] lov voltage local network station
         # [4] medium voltage grid, [5] medium voltage transformer station, [6] High Voltage
         # These can be associated with different output_max and capex for each level
-        # default values for output_max from https://www.stromnetz-hamburg.de/netzanschluss/netzanschlussanfrage/
+        # default values for output_max from
+        # https://www.stromnetz-hamburg.de/netzanschluss/netzanschlussanfrage/
 
         self.grid_level = 1
 

--- a/smooth/examples/example_plotting_dicts.py
+++ b/smooth/examples/example_plotting_dicts.py
@@ -18,10 +18,10 @@ comp_dict_german = {
 }
 
 bus_dict_german = {
-    'bel': 'Elektrische Energie',
-    'bel_wind':	'Wind Energie',
-    'bel_pv': 'PV Energie',
-    'bth': 'Thermische Energie',
+    'bel': 'Elektrische Leistung',
+    'bel_wind':	'Wind Leistung',
+    'bel_pv': 'PV Leistung',
+    'bth': 'Thermische Leistung',
     'bh2_lp': 'Wasserstoff-Fluss bei Niederdruck',
     'bh2_mp': 'Wasserstoff-Fluss bei Mitteldruck',
     'bh2_hp': 'Wasserstoff-Fluss bei Hochdruck',
@@ -29,14 +29,14 @@ bus_dict_german = {
 }
 
 y_dict_german = {
-    'bel': 'Energie in Wh',
-    'bel_wind':	'Energie in Wh',
-    'bel_pv': 'Energie in Wh',
-    'bth': 'Energie in Wh',
-    'bh2_lp': 'Wasserstoff in kg',
-    'bh2_mp': 'Wasserstoff in kg',
-    'bh2_hp': 'Wasserstoff in kg',
-    'bch4': 'Biomethan in kg',
+    'bel': 'Leistung in W',
+    'bel_wind':	'Leistung in W',
+    'bel_pv': 'Leistung in W',
+    'bth': 'Leistung in W',
+    'bh2_lp': 'Wasserstoff in kg/h',
+    'bh2_mp': 'Wasserstoff in kg/h',
+    'bh2_hp': 'Wasserstoff in kg/h',
+    'bch4': 'Biomethan in kg/h',
 }
 
 # ------------------- ENGLISH DICTIONARIES -------------------
@@ -59,10 +59,10 @@ comp_dict_english = {
 }
 
 bus_dict_english = {
-    'bel': 'Electrical energy',
-    'bel_wind':	'Wind energy',
-    'bel_pv': 'PV energy',
-    'bth': 'Thermal energy',
+    'bel': 'Electrical power',
+    'bel_wind':	'Wind power',
+    'bel_pv': 'PV power',
+    'bth': 'Thermal power',
     'bh2_lp': 'Low pressure hydrogen flow',
     'bh2_mp': 'Medium pressure hydrogen flow',
     'bh2_hp': 'High pressure hydrogen flow',
@@ -70,12 +70,12 @@ bus_dict_english = {
 }
 
 y_dict_english = {
-    'bel': 'Energy in Wh',
-    'bel_wind':	'Energy in Wh',
-    'bel_pv': 'Energy in Wh',
-    'bth': 'Energy in Wh',
-    'bh2_lp': 'Hydrogen in kg',
-    'bh2_mp': 'Hydrogen in kg',
-    'bh2_hp': 'Hydrogen in kg',
-    'bch4': 'Biomethane in kg',
+    'bel': 'Power in W',
+    'bel_wind':	'Power in W',
+    'bel_pv': 'Power in W',
+    'bth': 'Power in W',
+    'bh2_lp': 'Hydrogen in kg/h',
+    'bh2_mp': 'Hydrogen in kg/h',
+    'bh2_hp': 'Hydrogen in kg/h',
+    'bch4': 'Biomethane in kg/h',
 }

--- a/smooth/framework/functions/plot_results.py
+++ b/smooth/framework/functions/plot_results.py
@@ -26,6 +26,8 @@ def plot_smooth_results(smooth_result, comp_label_dict=comp_dict_german,
             plt.ylabel(y_dict[this_bus])
         except KeyError:
             plt.title('bus: ' + this_bus)
+            
+        plt.grid()
 
         locs, labels = plt.xticks()
         locs_new = np.arange(0, len(this_flow)+1, np.floor(abs(locs[0])))

--- a/smooth/framework/functions/plot_results.py
+++ b/smooth/framework/functions/plot_results.py
@@ -1,56 +1,32 @@
 from matplotlib import pyplot as plt
+from smooth.framework.simulation_parameters import SimulationParameters
 from smooth.framework.functions.functions import extract_flow_per_bus
 from smooth.examples.example_plotting_dicts import comp_dict_german, bus_dict_german, y_dict_german
-import numpy as np
 
 
 def plot_smooth_results(smooth_result, comp_label_dict=comp_dict_german,
                         bus_dict=bus_dict_german, y_dict=y_dict_german):
-    """Create figures of smooth run.
-
-    All plots are drawn in a new window.
-
-    :param smooth_results: result from run_smooth containing all components
-    :type smooth_results: list of :class:`~smooth.components.component.Component`
-    :param comp_label_dict: component labels,
-        key being the component name in the model and value the name to display.
-        Defaults to comp_dict_german from example_plotting_dicts.
-    :type comp_label_dict: dictionary, optional
-    :param bus_dict: bus labels,
-        key being the bus name in the model and value the name to display.
-        Defaults to bus_dict_german from example_plotting_dicts.
-    :type bus_dict: dictionary, optional
-    :param y_dict: labels for y-axes,
-        key being the bus names from the model to plot and value the y-axis labels.
-        Defaults to y_dict_german from example_plotting_dicts.
-    :type y_dict: dictionary, optional
-    """
-
     # Extract dict containing the busses that will be plotted.
     busses_to_plot = extract_flow_per_bus(smooth_result, comp_label_dict)
+
+    # get first sim_params from smooth_result component for interval_time
+    sim_params = next(
+        (comp.sim_params for comp in smooth_result if hasattr(comp, 'sim_params')),
+        SimulationParameters({})  # default values
+    )
 
     # Plot each bus in a new window.
     for this_bus in busses_to_plot:
         for this_component, this_flow in busses_to_plot[this_bus].items():
-            plt.plot(this_flow, label=str(this_component))
+            # get time axis (in hours, interval_time is in minutes)
+            timeseries = [sim_params.interval_time/60 * t for t in range(len(this_flow))]
+            plt.plot(timeseries, this_flow, label=str(this_component))
         plt.legend()
-        if smooth_result[0].sim_params.interval_time == 60:
-            plt.xlabel('Stunden')
-        elif smooth_result[0].sim_params.interval_time == 1:
-            plt.xlabel('Minuten')
-        else:
-            plt.xlabel('Zeitschritt (≙' + str(smooth_result[0].sim_params.interval_time) + ' min)')
-
+        plt.xlabel('Stunden des Jahres')
         try:
             plt.title(bus_dict[this_bus])
             plt.ylabel(y_dict[this_bus])
         except KeyError:
             plt.title('bus: ' + this_bus)
-            # no label for y axis
 
-        plt.grid()
-
-        locs, labels = plt.xticks()
-        locs_new = np.arange(0, len(this_flow)+1, np.floor(abs(locs[0])))
-        plt.xticks(locs_new)
         plt.show()

--- a/smooth/framework/functions/plot_results.py
+++ b/smooth/framework/functions/plot_results.py
@@ -1,6 +1,7 @@
 from matplotlib import pyplot as plt
 from smooth.framework.functions.functions import extract_flow_per_bus
 from smooth.examples.example_plotting_dicts import comp_dict_german, bus_dict_german, y_dict_german
+import numpy as np
 
 
 def plot_smooth_results(smooth_result, comp_label_dict=comp_dict_german,
@@ -13,11 +14,20 @@ def plot_smooth_results(smooth_result, comp_label_dict=comp_dict_german,
         for this_component, this_flow in busses_to_plot[this_bus].items():
             plt.plot(this_flow, label=str(this_component))
         plt.legend()
-        plt.xlabel('Stunden des Jahres')
+        if smooth_result[0].sim_params.interval_time == 60:
+            plt.xlabel('Stunden')
+        elif smooth_result[0].sim_params.interval_time == 1:
+            plt.xlabel('Minuten')
+        else:
+            plt.xlabel('Zeitschritt')
+
         try:
             plt.title(bus_dict[this_bus])
             plt.ylabel(y_dict[this_bus])
         except KeyError:
             plt.title('bus: ' + this_bus)
 
+        locs, labels = plt.xticks()
+        locs_new = np.arange(0, len(this_flow)+1, np.floor(abs(locs[0])))
+        plt.xticks(locs_new)
         plt.show()

--- a/smooth/framework/functions/plot_results.py
+++ b/smooth/framework/functions/plot_results.py
@@ -19,7 +19,7 @@ def plot_smooth_results(smooth_result, comp_label_dict=comp_dict_german,
         elif smooth_result[0].sim_params.interval_time == 1:
             plt.xlabel('Minuten')
         else:
-            plt.xlabel('Zeitschritt')
+            plt.xlabel('Zeitschritt (≙' + str(smooth_result[0].sim_params.interval_time) + ' min)')
 
         try:
             plt.title(bus_dict[this_bus])

--- a/smooth/framework/functions/plot_results.py
+++ b/smooth/framework/functions/plot_results.py
@@ -26,7 +26,7 @@ def plot_smooth_results(smooth_result, comp_label_dict=comp_dict_german,
             plt.ylabel(y_dict[this_bus])
         except KeyError:
             plt.title('bus: ' + this_bus)
-            
+
         plt.grid()
 
         locs, labels = plt.xticks()


### PR DESCRIPTION
This pull request is on hold. It is being replaced by 3 individual PRs: #181, #183 and #184 


This pull request incorporates some changes. It makes PR #155 obsolete.

1. The interval time can now be adjusted, solving issues #159 and #152 
2. There is a new component "variable_grid"
3. There is a new component "variable_battery"

Therefore the following changes have been made;
1. The components "component.py", "component_battery.py", "component_sink.py", and "component_supply.py"
and the file "example_plotting_dicts.py" have been corrected. The underlying idea is, that all flows in oemof are designed as time dependent (like Power: W/kW) and automatically adjusted to the intervaltime. Until now flows in smooth have been written as in absolute values (like Energy: Wh/kWh). This commit changes this for the mentioned files, (all?) other components will have to be changed accordingly in order to be able to change the interval time and still get correct outputs. As long as one calculates in hours (interval_time = 60) all components will produce correct outputs.

plot_results.py has been changed to account for different interval times by Stefan in PR #175 and I incorporated these changes here in order to avoid merge conflicts.

2. The new component "variable_grid" has been written, so that the optimizer (run_optimization) can optimize the type of grid connection (grid_level). Therefore different levels can be efined regarding their output_max and capex.

3. Similarly the component "variable_battery" can be used in order for the optimizer to select the best suited battery.