### PR TITLE
Make interval time adjustable

### DIFF
--- a/smooth/components/component.py
+++ b/smooth/components/component.py
@@ -127,12 +127,12 @@ class Component:
         if self.variable_costs is not None:
             this_dependency_value = self.flows[self.dependency_flow_costs][sim_params.i_interval]
             self.results['variable_costs'][sim_params.i_interval] = this_dependency_value * \
-                self.variable_costs
+                self.variable_costs * sim_params.interval_time/60
         # Update the artificial costs for this time step [EUR].
         if self.artificial_costs is not None:
             this_dependency_value = self.flows[self.dependency_flow_costs][sim_params.i_interval]
             self.results['art_costs'][sim_params.i_interval] = this_dependency_value * \
-                self.artificial_costs
+                self.artificial_costs * sim_params.interval_time/60
 
     def update_var_emissions(self, results, sim_params):
         # Track the emissions of a component for each time step.
@@ -152,7 +152,7 @@ class Component:
             this_dependency_value = \
                 self.flows[self.dependency_flow_emissions][sim_params.i_interval]
             self.results['variable_emissions'][sim_params.i_interval] = \
-                this_dependency_value * self.variable_emissions
+                this_dependency_value * self.variable_emissions * sim_params.interval_time/60
 
     # ------ ADD COSTS AND ARTIFICIAL COSTS TO A PARAMETER IF THEY ARE NOT NONE ------
 

--- a/smooth/components/component.py
+++ b/smooth/components/component.py
@@ -115,7 +115,7 @@ class Component:
         time derivatives (e.g. [W] or [kg/h]) and hence have to be adjusted to interval time [h].
 
         :param results: oemof result object for this time step
-        :param sim_params: simulation parameters defined by the user
+        :param sim_params: simulation parameters defined by the user 
         """
 
         # First create an empty cost and art. cost array for this component, if

--- a/smooth/components/component.py
+++ b/smooth/components/component.py
@@ -109,10 +109,14 @@ class Component:
     # ------------------- UPDATE THE COSTS -------------------
 
     def update_var_costs(self, results, sim_params):
-        # Track the costs and artificial costs of a component for each time step.
-        # Parameters:
-        #  results: oemof result object for this time step.
-        #  sim_params: simulation parameters defined by the user.
+        """
+        Track the costs and artificial costs of a component for each time step.
+        Costs are associated with absolute values (e.g. [Wh] or [kg]), flows are given in
+        time derivatives (e.g. [W] or [kg/h]) and hence have to be adjusted to interval time [h].
+
+        :param results: oemof result object for this time step
+        :param sim_params: simulation parameters defined by the user
+        """
 
         # First create an empty cost and art. cost array for this component, if
         # it hasn't been created before.
@@ -124,25 +128,25 @@ class Component:
             self.results['art_costs'] = [0] * sim_params.n_intervals
 
         # Update the costs for this time step [EUR].
-        # Costs are associated with absolute values (e.g. [Wh] org [kg]), flows are given in
-        # time derivatives (e.g. [W] org [kg/h]) and have to be adjusted to interval time [h]
         if self.variable_costs is not None:
             this_dependency_value = self.flows[self.dependency_flow_costs][sim_params.i_interval]
             self.results['variable_costs'][sim_params.i_interval] = \
                 this_dependency_value * sim_params.interval_time/60 * self.variable_costs
         # Update the artificial costs for this time step [EUR].
-        # Costs are associated with absolute values (e.g. [Wh] org [kg]), flows are given in
-        # time derivatives (e.g. [W] org [kg/h]) and have to be adjusted to interval time [h]
         if self.artificial_costs is not None:
             this_dependency_value = self.flows[self.dependency_flow_costs][sim_params.i_interval]
             self.results['art_costs'][sim_params.i_interval] = \
                 this_dependency_value * sim_params.interval_time/60 * self.artificial_costs
 
     def update_var_emissions(self, results, sim_params):
-        # Track the emissions of a component for each time step.
-        # Parameters:
-        #  results: oemof result object for this time step.
-        #  sim_params: simulation parameters defined by the user.
+        """
+        Track the emissions of a component for each time step.
+        Emissions are associated with absolute values (e.g. [Wh] or [kg]), flows are given in
+        time derivatives (e.g. [W] or [kg/h]) and hence have to be adjusted to interval time [h].
+
+        :param results: oemof result object for this time step
+        :param sim_params: simulation parameters defined by the user
+        """
 
         # First create an empty emission array for this component, if it hasn't been created before.
         if 'variable_emissions' not in self.results:
@@ -152,8 +156,6 @@ class Component:
 
         # Update the emissions for this time step [kg]. Before, verify if a
         # flow name is given as emission dependency.
-        # Emissions are associated with absolute values (e.g. [Wh] org [kg]), flows are given in
-        # time derivatives (e.g. [W] org [kg/h]) and have to be adjusted to interval time [h]
         if self.variable_emissions is not None:
             this_dependency_value = \
                 self.flows[self.dependency_flow_emissions][sim_params.i_interval]

--- a/smooth/components/component.py
+++ b/smooth/components/component.py
@@ -124,15 +124,19 @@ class Component:
             self.results['art_costs'] = [0] * sim_params.n_intervals
 
         # Update the costs for this time step [EUR].
+        # Costs are associated with absolute values (e.g. [Wh] org [kg]), flows are given in
+        # time derivatives (e.g. [W] org [kg/h]) and have to be adjusted to interval time [h]
         if self.variable_costs is not None:
             this_dependency_value = self.flows[self.dependency_flow_costs][sim_params.i_interval]
-            self.results['variable_costs'][sim_params.i_interval] = this_dependency_value * \
-                self.variable_costs * sim_params.interval_time/60
+            self.results['variable_costs'][sim_params.i_interval] = \
+                this_dependency_value * sim_params.interval_time/60 * self.variable_costs
         # Update the artificial costs for this time step [EUR].
+        # Costs are associated with absolute values (e.g. [Wh] org [kg]), flows are given in
+        # time derivatives (e.g. [W] org [kg/h]) and have to be adjusted to interval time [h]
         if self.artificial_costs is not None:
             this_dependency_value = self.flows[self.dependency_flow_costs][sim_params.i_interval]
-            self.results['art_costs'][sim_params.i_interval] = this_dependency_value * \
-                self.artificial_costs * sim_params.interval_time/60
+            self.results['art_costs'][sim_params.i_interval] = \
+                this_dependency_value * sim_params.interval_time/60 * self.artificial_costs
 
     def update_var_emissions(self, results, sim_params):
         # Track the emissions of a component for each time step.
@@ -148,11 +152,13 @@ class Component:
 
         # Update the emissions for this time step [kg]. Before, verify if a
         # flow name is given as emission dependency.
+        # Emissions are associated with absolute values (e.g. [Wh] org [kg]), flows are given in
+        # time derivatives (e.g. [W] org [kg/h]) and have to be adjusted to interval time [h]
         if self.variable_emissions is not None:
             this_dependency_value = \
                 self.flows[self.dependency_flow_emissions][sim_params.i_interval]
             self.results['variable_emissions'][sim_params.i_interval] = \
-                this_dependency_value * self.variable_emissions * sim_params.interval_time/60
+                this_dependency_value * sim_params.interval_time/60 * self.variable_emissions
 
     # ------ ADD COSTS AND ARTIFICIAL COSTS TO A PARAMETER IF THEY ARE NOT NONE ------
 

--- a/smooth/components/component.py
+++ b/smooth/components/component.py
@@ -115,7 +115,7 @@ class Component:
         time derivatives (e.g. [W] or [kg/h]) and hence have to be adjusted to interval time [h].
 
         :param results: oemof result object for this time step
-        :param sim_params: simulation parameters defined by the user 
+        :param sim_params: simulation parameters defined by the user
         """
 
         # First create an empty cost and art. cost array for this component, if

--- a/smooth/components/component_battery.py
+++ b/smooth/components/component_battery.py
@@ -116,7 +116,8 @@ class Battery(Component):
             ) / self.efficiency_charge
         self.p_out_max = min(
             self.c_rate_discharge * self.battery_capacity,
-            (self.soc * self.battery_capacity) / (self.sim_params.interval_time/60))
+            (self.soc * self.battery_capacity) / (self.sim_params.interval_time/60)
+            )
 
     def create_oemof_model(self, busses, _):
         """ Create oemof model """

--- a/smooth/components/component_battery.py
+++ b/smooth/components/component_battery.py
@@ -105,13 +105,18 @@ class Battery(Component):
         # Therefore we need to divide by the efficiency_charge.  Due to the
         # inflow_conversion_factor (in "create oemof model") the battery will
         # then receive right amount.
+        # Flows are calculated as Power [W], so the amount of charge- or dischargeable
+        # energy [Wh] has to be divided by the intervaltime [h]  (P = E / t)
+        # The c-rate is given in [W/Wh], multiplication with capacity [Wh] results in power [W]
 
-        self.p_in_max = min(self.c_rate_charge * self.battery_capacity,
-                            (self.battery_capacity - self.soc * self.battery_capacity)
-                            * 60/self.sim_params.interval_time) / self.efficiency_charge
+        self.p_in_max = min(
+            self.c_rate_charge * self.battery_capacity,
+            (self.battery_capacity - self.soc * self.battery_capacity) /
+            (self.sim_params.interval_time/60)
+            ) / self.efficiency_charge
         self.p_out_max = min(
             self.c_rate_discharge * self.battery_capacity,
-            (self.soc * self.battery_capacity) * 60/self.sim_params.interval_time)
+            (self.soc * self.battery_capacity) / (self.sim_params.interval_time/60))
 
     def create_oemof_model(self, busses, _):
         """ Create oemof model """

--- a/smooth/components/component_energy_demand_from_csv.py
+++ b/smooth/components/component_energy_demand_from_csv.py
@@ -5,7 +5,11 @@ import smooth.framework.functions.functions as func
 
 
 class EnergyDemandFromCsv(Component):
-    """ Energy demand created through this class from a csv file """
+    """ Energy demand per hour is created through this class from a csv file
+
+    Each line in the csv file represents one timestep and each value
+    the respective power demand (e.g. in [W]) at that timestep
+    """
 
     def __init__(self, params):
 

--- a/smooth/components/component_energy_source_from_csv.py
+++ b/smooth/components/component_energy_source_from_csv.py
@@ -5,7 +5,11 @@ import smooth.framework.functions.functions as func
 
 
 class EnergySourceFromCsv (Component):
-    """ General energy sources are created through this class by importing csv files """
+    """ General energy sources are created through this class by importing csv files
+
+    Each line in the csv file represents one timestep and each value
+    the respective power (e.g. in [W]) coming from the energy source at that timestep
+    """
 
     def __init__(self, params):
 

--- a/smooth/components/component_sink.py
+++ b/smooth/components/component_sink.py
@@ -13,8 +13,8 @@ class Sink(Component):
         # ------------------- PARAMETERS -------------------
         self.name = 'Grid_default_name'
 
-        # Maximum input per timestep of commodity:
-        # e.g. for the electricity grid [Wh], thermal grid [Wh], CH4 grid [Wh]
+        # Maximum input per hour:
+        # e.g. for the electricity grid [W], thermal grid [W], CH4 grid [kg/h]
         self.input_max = 800000000
 
         self.bus_in = None

--- a/smooth/components/component_supply.py
+++ b/smooth/components/component_supply.py
@@ -14,8 +14,8 @@ class Supply (Component):
 
         # ------------------- PARAMETERS -------------------
         self.name = 'Grid_default_name'
-        # Maximum output per timestep of commodity:
-        # e.g. for the electricity grid [Wh], thermal grid [Wh], CH4 grid [kg/h]
+        # Maximum output per hour:
+        # e.g. for the electricity grid [W], thermal grid [W], CH4 grid [kg/h]
         self.output_max = 8000000
 
         self.bus_out = None

--- a/smooth/examples/example_plotting_dicts.py
+++ b/smooth/examples/example_plotting_dicts.py
@@ -74,7 +74,7 @@ bus_dict_english = {
 }
 
 y_dict_english = {
-    'bel': 'Power in W',
+    'bel': 'Power in W', 
     'bel_wind': 'Power in W',
     'bel_pv': 'Power in W',
     'bth': 'Power in W',

--- a/smooth/examples/example_plotting_dicts.py
+++ b/smooth/examples/example_plotting_dicts.py
@@ -16,12 +16,12 @@ comp_dict_german = {
     'CHP_Methane': 'Biogas-BHKW',
     'ch4_grid': 'Biogas-Zufuhr',
     'h2_compressor_from_ely': 'Wasserstoffkompressor (Niederdruck)',
-    'li_battery': 'Lithium Batterie',
+    'li_battery': 'Lithium-Batterie',
 }
 
 bus_dict_german = {
     'bel': 'Elektrische Leistung',
-    'bel_wind':	'Wind Leistung',
+    'bel_wind': 'Wind Leistung',
     'bel_pv': 'PV Leistung',
     'bth': 'Thermische Leistung',
     'bh2_lp': 'Wasserstoff-Fluss bei Niederdruck',
@@ -32,7 +32,7 @@ bus_dict_german = {
 
 y_dict_german = {
     'bel': 'Leistung in W',
-    'bel_wind':	'Leistung in W',
+    'bel_wind': 'Leistung in W',
     'bel_pv': 'Leistung in W',
     'bth': 'Leistung in W',
     'bh2_lp': 'Wasserstoff in kg/h',
@@ -64,7 +64,7 @@ comp_dict_english = {
 
 bus_dict_english = {
     'bel': 'Electrical power',
-    'bel_wind':	'Wind power',
+    'bel_wind': 'Wind power',
     'bel_pv': 'PV power',
     'bth': 'Thermal power',
     'bh2_lp': 'Low pressure hydrogen flow',
@@ -75,7 +75,7 @@ bus_dict_english = {
 
 y_dict_english = {
     'bel': 'Power in W',
-    'bel_wind':	'Power in W',
+    'bel_wind': 'Power in W',
     'bel_pv': 'Power in W',
     'bth': 'Power in W',
     'bh2_lp': 'Hydrogen in kg/h',

--- a/smooth/examples/example_plotting_dicts.py
+++ b/smooth/examples/example_plotting_dicts.py
@@ -5,6 +5,7 @@ comp_dict_german = {
     'this_pem_ely': 'PEM-Elektrolyseur',
     'pv_output': 'PV-Anlage',
     'wind_output': 'WE-Anlage',
+    'el_demand': 'Strombedarf',
     'th_demand': 'Heizbedarf',
     'h2_demand': 'Wasserstoffbedarf',
     'h2_compressor': 'Wasserstoffkompressor (Hochdruck)',
@@ -15,6 +16,7 @@ comp_dict_german = {
     'CHP_Methane': 'Biogas-BHKW',
     'ch4_grid': 'Biogas-Zufuhr',
     'h2_compressor_from_ely': 'Wasserstoffkompressor (Niederdruck)',
+    'li_battery': 'Lithium Batterie',
 }
 
 bus_dict_german = {
@@ -46,6 +48,7 @@ comp_dict_english = {
     'this_pem_ely': 'PEM electrolyser',
     'pv_output': 'PV system',
     'wind_output': 'WE system',
+    'el_demand': 'Electricity demand',
     'th_demand': 'Thermal demand',
     'h2_demand': 'Hydrogen demand',
     'h2_compressor': 'Hydrogen compressor (higher pressure)',
@@ -56,6 +59,7 @@ comp_dict_english = {
     'CHP_Methane': 'Methane CHP',
     'ch4_grid': 'Biogas supply',
     'h2_compressor_from_ely': 'Hydrogen compressor (lower pressure)',
+    'li_battery': 'Lithium battery',
 }
 
 bus_dict_english = {

--- a/smooth/examples/example_plotting_dicts.py
+++ b/smooth/examples/example_plotting_dicts.py
@@ -18,10 +18,10 @@ comp_dict_german = {
 }
 
 bus_dict_german = {
-    'bel': 'Elektrische Energie',
-    'bel_wind':	'Wind Energie',
-    'bel_pv': 'PV Energie',
-    'bth': 'Thermische Energie',
+    'bel': 'Elektrische Leistung',
+    'bel_wind':	'Wind Leistung',
+    'bel_pv': 'PV Leistung',
+    'bth': 'Thermische Leistung',
     'bh2_lp': 'Wasserstoff-Fluss bei Niederdruck',
     'bh2_mp': 'Wasserstoff-Fluss bei Mitteldruck',
     'bh2_hp': 'Wasserstoff-Fluss bei Hochdruck',
@@ -29,14 +29,14 @@ bus_dict_german = {
 }
 
 y_dict_german = {
-    'bel': 'Energie in Wh',
-    'bel_wind':	'Energie in Wh',
-    'bel_pv': 'Energie in Wh',
-    'bth': 'Energie in Wh',
-    'bh2_lp': 'Wasserstoff in kg',
-    'bh2_mp': 'Wasserstoff in kg',
-    'bh2_hp': 'Wasserstoff in kg',
-    'bch4': 'Biomethan in kg',
+    'bel': 'Leistung in W',
+    'bel_wind':	'Leistung in W',
+    'bel_pv': 'Leistung in W',
+    'bth': 'Leistung in W',
+    'bh2_lp': 'Wasserstoff in kg/h',
+    'bh2_mp': 'Wasserstoff in kg/h',
+    'bh2_hp': 'Wasserstoff in kg/h',
+    'bch4': 'Biomethan in kg/h',
 }
 
 # ------------------- ENGLISH DICTIONARIES -------------------
@@ -59,10 +59,10 @@ comp_dict_english = {
 }
 
 bus_dict_english = {
-    'bel': 'Electrical energy',
-    'bel_wind':	'Wind energy',
-    'bel_pv': 'PV energy',
-    'bth': 'Thermal energy',
+    'bel': 'Electrical power',
+    'bel_wind':	'Wind power',
+    'bel_pv': 'PV power',
+    'bth': 'Thermal power',
     'bh2_lp': 'Low pressure hydrogen flow',
     'bh2_mp': 'Medium pressure hydrogen flow',
     'bh2_hp': 'High pressure hydrogen flow',
@@ -70,12 +70,12 @@ bus_dict_english = {
 }
 
 y_dict_english = {
-    'bel': 'Energy in Wh',
-    'bel_wind':	'Energy in Wh',
-    'bel_pv': 'Energy in Wh',
-    'bth': 'Energy in Wh',
-    'bh2_lp': 'Hydrogen in kg',
-    'bh2_mp': 'Hydrogen in kg',
-    'bh2_hp': 'Hydrogen in kg',
-    'bch4': 'Biomethane in kg',
+    'bel': 'Power in W',
+    'bel_wind':	'Power in W',
+    'bel_pv': 'Power in W',
+    'bth': 'Power in W',
+    'bh2_lp': 'Hydrogen in kg/h',
+    'bh2_mp': 'Hydrogen in kg/h',
+    'bh2_hp': 'Hydrogen in kg/h',
+    'bch4': 'Biomethane in kg/h',
 }


### PR DESCRIPTION
The interval time can now be adjusted, solving issues #159 and #152

This PR is the third of three to split PR #180 into manageable parts.

The components 

- component.py
- component_battery.py
- component_sink.py
- component_supply.py
- component_energy_demand_from_csv.py 
- component_energy_source_from_csv.py 

and the file 

- example_plotting_dicts.py

have been corrected. 

The underlying idea is, that all flows in oemof are designed as time dependent (like Power: [W] or [kW] or material flow per hour [kg/h]) and automatically adjusted to the intervaltime. Until now flows in smooth have been written as if they were interpreted in absolute values (like Energy: [Wh] or [kWh] respectivels [kg]). This commit changes this for the mentioned files, (all?) other components will have to be changed accordingly in order to be able to change the interval time and still get correct outputs.

As long as one calculates in hours (interval_time = 60) all components will produce correct outputs before and after merging this PR.