### PR TITLE
add addspec to keys in update_cost

### DIFF
--- a/smooth/framework/functions/update_fitted_cost.py
+++ b/smooth/framework/functions/update_fitted_cost.py
@@ -289,14 +289,13 @@ def get_addspec(component, fitting_dict, index, dependant_value):
         'No previously calculated costs found, ' \
         'use \'addspec\' key only to add costs to existing costs'
 
-    oldcost = fitting_dict['cost']
     # Get the fitting value, which is the current cost if "cost" is chosen.
     if fitting_dict['fitting_value'][index] == 'cost':
         fitting_value = fitting_dict['cost']
     else:
         fitting_value = fitting_dict['fitting_value'][index]
     # Calculate the costs.
-    cost = oldcost + dependant_value * fitting_value
+    cost = fitting_dict['cost'] + dependant_value * fitting_value
 
     # Return the costs.
     return cost


### PR DESCRIPTION
I added a new key to enable for addition of costs - in this case 'spec' costs -  when those are being calculated.

Check the feature using this demo:
[example_addspec.zip](https://github.com/rl-institut/smooth/files/5103334/example_addspec.zip)

Some small in the docstring of 'update_fitted_cost.py' typos were also corrected.

An error catch (assert) statement was included, in case 'addspec' or 'cost' in 'spec' key is used in a wrong way.