### PR TITLE
include component name in custom constraints

### DIFF
--- a/smooth/components/component_electrolyzer_waste_heat.py
+++ b/smooth/components/component_electrolyzer_waste_heat.py
@@ -213,9 +213,8 @@ class ElectrolyzerWasteHeat(Electrolyzer):
             expr += -model.flow[busses[self.bus_el], self.model_h2, t]
             return expr == 0
 
-        model_to_solve.electrolyzer_flow_ratio_fix = po.Constraint(
-            model_to_solve.TIMESTEPS, rule=electrolyzer_ratio_rule
-        )
+        constraint = po.Constraint(model_to_solve.TIMESTEPS, rule=electrolyzer_ratio_rule)
+        setattr(model_to_solve, 'electrolyzer_flow_ratio_fix_{}'.format(self.name), constraint)
 
     def update_flows(self, results, sim_params):
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.

--- a/smooth/components/component_electrolyzer_waste_heat.py
+++ b/smooth/components/component_electrolyzer_waste_heat.py
@@ -214,9 +214,9 @@ class ElectrolyzerWasteHeat(Electrolyzer):
             return expr == 0
 
         setattr(model_to_solve,
-            'electrolyzer_flow_ratio_fix_{}'.format(self.name.replace(' ', '')),
-            po.Constraint(model_to_solve.TIMESTEPS, rule=electrolyzer_ratio_rule)
-        )
+                'electrolyzer_flow_ratio_fix_{}'.format(self.name.replace(' ', '')),
+                po.Constraint(model_to_solve.TIMESTEPS, rule=electrolyzer_ratio_rule)
+                )
 
     def update_flows(self, results, sim_params):
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.

--- a/smooth/components/component_electrolyzer_waste_heat.py
+++ b/smooth/components/component_electrolyzer_waste_heat.py
@@ -213,8 +213,10 @@ class ElectrolyzerWasteHeat(Electrolyzer):
             expr += -model.flow[busses[self.bus_el], self.model_h2, t]
             return expr == 0
 
-        constraint = po.Constraint(model_to_solve.TIMESTEPS, rule=electrolyzer_ratio_rule)
-        setattr(model_to_solve, 'electrolyzer_flow_ratio_fix_{}'.format(self.name), constraint)
+        setattr(model_to_solve,
+            'electrolyzer_flow_ratio_fix_{}'.format(self.name.replace(' ', '')),
+            po.Constraint(model_to_solve.TIMESTEPS, rule=electrolyzer_ratio_rule)
+        )
 
     def update_flows(self, results, sim_params):
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.

--- a/smooth/components/component_fuel_cell_chp.py
+++ b/smooth/components/component_fuel_cell_chp.py
@@ -166,9 +166,9 @@ class FuelCellChp(Component):
             return (expr == 0)
 
         setattr(model_to_solve,
-            'chp_flow_ratio_fix_{}'.format(self.name.replace(' ', '')),
-            po.Constraint(model_to_solve.TIMESTEPS, rule=chp_ratio_rule)
-        )
+                'chp_flow_ratio_fix_{}'.format(self.name.replace(' ', '')),
+                po.Constraint(model_to_solve.TIMESTEPS, rule=chp_ratio_rule)
+                )
 
     def update_flows(self, results, sim_params):
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.

--- a/smooth/components/component_fuel_cell_chp.py
+++ b/smooth/components/component_fuel_cell_chp.py
@@ -165,8 +165,8 @@ class FuelCellChp(Component):
             expr += - model.flow[busses[self.bus_h2], self.model_el, t]
             return (expr == 0)
 
-        model_to_solve.chp_flow_ratio_fix = po.Constraint(
-            model_to_solve.TIMESTEPS, rule=chp_ratio_rule)
+        constraint = po.Constraint(model_to_solve.TIMESTEPS, rule=chp_ratio_rule)
+        setattr(model_to_solve, 'chp_flow_ratio_fix_{}'.format(self.name), constraint)
 
     def update_flows(self, results, sim_params):
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.

--- a/smooth/components/component_fuel_cell_chp.py
+++ b/smooth/components/component_fuel_cell_chp.py
@@ -165,8 +165,10 @@ class FuelCellChp(Component):
             expr += - model.flow[busses[self.bus_h2], self.model_el, t]
             return (expr == 0)
 
-        constraint = po.Constraint(model_to_solve.TIMESTEPS, rule=chp_ratio_rule)
-        setattr(model_to_solve, 'chp_flow_ratio_fix_{}'.format(self.name), constraint)
+        setattr(model_to_solve,
+            'chp_flow_ratio_fix_{}'.format(self.name.replace(' ', '')),
+            po.Constraint(model_to_solve.TIMESTEPS, rule=chp_ratio_rule)
+        )
 
     def update_flows(self, results, sim_params):
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.

--- a/smooth/components/component_gas_engine_chp_biogas.py
+++ b/smooth/components/component_gas_engine_chp_biogas.py
@@ -188,8 +188,10 @@ class GasEngineChpBiogas(Component):
             expr += - model.flow[busses[self.bus_ch4], self.model_el, t]
             return (expr == 0)
 
-        constraint = po.Constraint(model_to_solve.TIMESTEPS, rule=chp_ratio_rule_methane)
-        setattr(model_to_solve, 'chp_flow_ratio_fix_methane_{}'.format(self.name), constraint)
+        setattr(model_to_solve,
+            'chp_flow_ratio_fix_methane_{}'.format(self.name.replace(' ', '')),
+            po.Constraint(model_to_solve.TIMESTEPS, rule=chp_ratio_rule_methane)
+        )
 
     def update_flows(self, results, sim_params):
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.

--- a/smooth/components/component_gas_engine_chp_biogas.py
+++ b/smooth/components/component_gas_engine_chp_biogas.py
@@ -189,9 +189,9 @@ class GasEngineChpBiogas(Component):
             return (expr == 0)
 
         setattr(model_to_solve,
-            'chp_flow_ratio_fix_methane_{}'.format(self.name.replace(' ', '')),
-            po.Constraint(model_to_solve.TIMESTEPS, rule=chp_ratio_rule_methane)
-        )
+                'chp_flow_ratio_fix_methane_{}'.format(self.name.replace(' ', '')),
+                po.Constraint(model_to_solve.TIMESTEPS, rule=chp_ratio_rule_methane)
+                )
 
     def update_flows(self, results, sim_params):
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.

--- a/smooth/components/component_gas_engine_chp_biogas.py
+++ b/smooth/components/component_gas_engine_chp_biogas.py
@@ -188,8 +188,8 @@ class GasEngineChpBiogas(Component):
             expr += - model.flow[busses[self.bus_ch4], self.model_el, t]
             return (expr == 0)
 
-        model_to_solve.chp_flow_ratio_fix_methane = po.Constraint(
-            model_to_solve.TIMESTEPS, rule=chp_ratio_rule_methane)
+        constraint = po.Constraint(model_to_solve.TIMESTEPS, rule=chp_ratio_rule_methane)
+        setattr(model_to_solve, 'chp_flow_ratio_fix_methane_{}'.format(self.name), constraint)
 
     def update_flows(self, results, sim_params):
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.

--- a/smooth/components/component_h2_chp.py
+++ b/smooth/components/component_h2_chp.py
@@ -198,8 +198,10 @@ class H2Chp(Component):
             expr += - model.flow[busses[self.bus_h2], self.model_el, t]
             return (expr == 0)
 
-        constraint = po.Constraint(model_to_solve.TIMESTEPS, rule=chp_ratio_rule)
-        setattr(model_to_solve, 'chp_flow_ratio_fix_{}'.format(self.name), constraint)
+        setattr(model_to_solve,
+            'chp_flow_ratio_fix_{}'.format(self.name.replace(' ', '')),
+            po.Constraint(model_to_solve.TIMESTEPS, rule=chp_ratio_rule)
+        )
 
     def update_flows(self, results, sim_params):
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.

--- a/smooth/components/component_h2_chp.py
+++ b/smooth/components/component_h2_chp.py
@@ -199,9 +199,9 @@ class H2Chp(Component):
             return (expr == 0)
 
         setattr(model_to_solve,
-            'chp_flow_ratio_fix_{}'.format(self.name.replace(' ', '')),
-            po.Constraint(model_to_solve.TIMESTEPS, rule=chp_ratio_rule)
-        )
+                'chp_flow_ratio_fix_{}'.format(self.name.replace(' ', '')),
+                po.Constraint(model_to_solve.TIMESTEPS, rule=chp_ratio_rule)
+                )
 
     def update_flows(self, results, sim_params):
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.

--- a/smooth/components/component_h2_chp.py
+++ b/smooth/components/component_h2_chp.py
@@ -198,8 +198,8 @@ class H2Chp(Component):
             expr += - model.flow[busses[self.bus_h2], self.model_el, t]
             return (expr == 0)
 
-        model_to_solve.chp_flow_ratio_fix = po.Constraint(
-            model_to_solve.TIMESTEPS, rule=chp_ratio_rule)
+        constraint = po.Constraint(model_to_solve.TIMESTEPS, rule=chp_ratio_rule)
+        setattr(model_to_solve, 'chp_flow_ratio_fix_{}'.format(self.name), constraint)
 
     def update_flows(self, results, sim_params):
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.

--- a/smooth/components/component_pem_electrolyzer.py
+++ b/smooth/components/component_pem_electrolyzer.py
@@ -163,8 +163,10 @@ class PemElectrolyzer(Component):
             expr += - model.flow[busses[self.bus_el], self.model_h2, t]
             return (expr == 0)
 
-        constraint = po.Constraint(model_to_solve.TIMESTEPS, rule=electrolyzer_ratio_rule)
-        setattr(model_to_solve, 'electrolyzer_flow_ratio_fix_{}'.format(self.name), constraint)
+        setattr(model_to_solve,
+            'electrolyzer_flow_ratio_fix_{}'.format(self.name.replace(' ', '')),
+            po.Constraint(model_to_solve.TIMESTEPS, rule=electrolyzer_ratio_rule)
+        )
 
     def update_flows(self, results, sim_params):
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.

--- a/smooth/components/component_pem_electrolyzer.py
+++ b/smooth/components/component_pem_electrolyzer.py
@@ -164,9 +164,9 @@ class PemElectrolyzer(Component):
             return (expr == 0)
 
         setattr(model_to_solve,
-            'electrolyzer_flow_ratio_fix_{}'.format(self.name.replace(' ', '')),
-            po.Constraint(model_to_solve.TIMESTEPS, rule=electrolyzer_ratio_rule)
-        )
+                'electrolyzer_flow_ratio_fix_{}'.format(self.name.replace(' ', '')),
+                po.Constraint(model_to_solve.TIMESTEPS, rule=electrolyzer_ratio_rule)
+                )
 
     def update_flows(self, results, sim_params):
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.

--- a/smooth/components/component_pem_electrolyzer.py
+++ b/smooth/components/component_pem_electrolyzer.py
@@ -163,8 +163,8 @@ class PemElectrolyzer(Component):
             expr += - model.flow[busses[self.bus_el], self.model_h2, t]
             return (expr == 0)
 
-        model_to_solve.electrolyzer_flow_ratio_fix = \
-            po.Constraint(model_to_solve.TIMESTEPS, rule=electrolyzer_ratio_rule)
+        constraint = po.Constraint(model_to_solve.TIMESTEPS, rule=electrolyzer_ratio_rule)
+        setattr(model_to_solve, 'electrolyzer_flow_ratio_fix_{}'.format(self.name), constraint)
 
     def update_flows(self, results, sim_params):
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.


### PR DESCRIPTION
Having two components that add custom constraints to the model no longer replaces the other constraint, which led to pyomo complaining. The name of the component is appended to the constraint attribute, making it unique within the model.

Fix #185 