### PR TITLE
Simplify installation of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,7 @@ install:
   # Install CBC solver
   - sudo apt-get install coinor-cbc
 
-  # Install specific commit of branch features/piecewise_linear_transformer of oemof/oemof-solph
-  # To be merged with pull request pull/592
-  - git clone https://github.com/oemof/oemof-solph.git
-  - cd oemof-solph
-  - git checkout 585b123e3dc02b191fead4d202ba60c057c473fd
-  - pip install .
-  - cd ..
-
-  # Install other smooth dependencies
+  # Install smooth dependencies
   - pip install -r requirements.txt
 
   # Install smooth itself

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,10 @@
 sphinx
 sphinx_rtd_theme
+
+matplotlib
+pandas
+numpy
+scipy
+dill
+git+https://github.com/oemof/oemof-solph.git@585b123e3dc02b191fead4d202ba60c057c473fd
+pyutilib==5.8.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,8 +2,8 @@ sphinx
 sphinx_rtd_theme
 
 matplotlib
-pandas
-numpy
+pandas<0.26
+numpy<1.18
 scipy
 dill
 git+https://github.com/oemof/oemof-solph.git@585b123e3dc02b191fead4d202ba60c057c473fd

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -19,43 +19,15 @@ Full documentation can be found soon.
 Installing smooth
 =================
 
-In order to use SMOOTH, the smooth package needs to be installed.
-
-Installation of oemof (specific version required)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Further, oemof has to be installed.
-While some smooth components are described by non-linear component behaviour, the oemof component
-PiecewiseLinearTransformer is needed. This component is currently in the review process, therefore
-the pull request containing this component needs to be downloaded from github directly and installed
-locally. This can be done by the following steps:
-
-1. Clone `oemof <https://github.com/oemof/oemof-solph>`_ to your local machine
+In order to use SMOOTH, the smooth package and its requirements need to be installed.
 
 .. code:: bash
 
-    git clone https://github.com/oemof/oemof-solph.git
+    pip install -r requirements.txt
+    python setup.py install
 
-2. In the oemof repo, fetch the pull request version `#592 <https://github.com/oemof/oemof-solph/pull/592>`_ ,
-which contains the component, to a new branch BRANCHNAME of your choice.
 
-.. code:: bash
-
-    git fetch origin pull/592/head:BRANCHNAME
-
-3. Checkout the branch BRANCHNAME of the pull request version.
-
-.. code:: bash
-
-    git checkout BRANCHNAME
-
-4. Install the pull request version of oemof with pip
-
-.. code:: bash
-
-    pip install .
-
-5. Install the solver for oemof (if you wasn't running oemof before). This can be done according to
+You also need to install the solver for oemof. This can be done according to
 `this <https://oemof.readthedocs.io/en/stable/installation_and_setup.html#installation-and-setup-label>`_
 documentation page.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib
-pandas
-numpy
+pandas<0.26
+numpy<1.18
 scipy
 dill
 git+https://github.com/oemof/oemof-solph.git@585b123e3dc02b191fead4d202ba60c057c473fd

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pandas
 numpy
 scipy
 dill
-#oemof
+git+ssh://git@github.com/oemof/oemof-solph.git@585b123e3dc02b191fead4d202ba60c057c473fd
 pyutilib==5.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pandas
 numpy
 scipy
 dill
-git+ssh://git@github.com/oemof/oemof-solph.git@585b123e3dc02b191fead4d202ba60c057c473fd
+git+https://github.com/oemof/oemof-solph.git@585b123e3dc02b191fead4d202ba60c057c473fd
 pyutilib==5.8.0

--- a/setup.py
+++ b/setup.py
@@ -8,4 +8,13 @@ setup(
     package_data={'smooth.examples': ['example_timeseries/*.csv']},
     license='GNU AFFERO GENERAL PUBLIC LICENSE - Version 3, 19 November 2007',
     long_description=open('README.md').read(),
+    #install_requires=[
+        #'oemof@git+git://github.com/oemof/oemof-solph@585b123e3dc02b191fead4d202ba60c057c473fd',
+        #'matplotlib',
+        #'pandas<0.26',
+        #'numpy<1.18',
+        #'scipy',
+        #'dill',
+        #'pyutilib==5.8.0',
+    #]
 )

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,4 @@ setup(
     package_data={'smooth.examples': ['example_timeseries/*.csv']},
     license='GNU AFFERO GENERAL PUBLIC LICENSE - Version 3, 19 November 2007',
     long_description=open('README.md').read(),
-    #install_requires=[
-        #'oemof@git+git://github.com/oemof/oemof-solph@585b123e3dc02b191fead4d202ba60c057c473fd',
-        #'matplotlib',
-        #'pandas<0.26',
-        #'numpy<1.18',
-        #'scipy',
-        #'dill',
-        #'pyutilib==5.8.0',
-    #]
 )


### PR DESCRIPTION
It's possible to specify a specific commit of another repository as a dependency for pip. This PR uses this features to add oemof to our requirements.txt. This should simplify the installation of smooth until our changes are merged into a proper release of oemof-solph.

I failed to also include the special oemof dependency into setup.py