### PR TITLE
changed default csv separator in energy_source_from_csv

### DIFF
--- a/smooth/components/component_energy_source_from_csv.py
+++ b/smooth/components/component_energy_source_from_csv.py
@@ -62,7 +62,7 @@ class EnergySourceFromCsv (Component):
         self.nominal_value = 1
         self.reference_value = 1
         self.csv_filename = None
-        self.csv_separator = ';'
+        self.csv_separator = ','
         self.column_title = 0
         self.path = os.path.dirname(__file__)
         self.bus_out = None


### PR DESCRIPTION
Small PR to change the default CSV separator to be ',' for all components (only energy_source_from_csv needed changing).

The examples in SMOOTH have been checked and all are working with this change, but any model definitions created outside of SMOOTH prior to this PR might need modification.