### PR TITLE
Fix/redundant sim params (updated)

### DIFF
--- a/smooth/components/component.py
+++ b/smooth/components/component.py
@@ -102,7 +102,7 @@ class Component:
 
     # ------------------- UPDATE THE FLOWS FOR EACH COMPONENT -------------------
 
-    def update_flows(self, results, sim_params, comp_name=None):
+    def update_flows(self, results, comp_name=None):
         """Updates the flows of a component for each time step.
 
         :param results: The oemof results for the given time step
@@ -130,9 +130,9 @@ class Component:
                 # Check if there already is an array to store the flow
                 # information, if not, create one.
                 if this_flow_name not in self.flows:
-                    self.flows[this_flow_name] = [None] * sim_params.n_intervals
+                    self.flows[this_flow_name] = [None] * self.sim_params.n_intervals
                 # Saving this flow value to the results file
-                self.flows[this_flow_name][sim_params.i_interval] = this_df[i_result][0]
+                self.flows[this_flow_name][self.sim_params.i_interval] = this_df[i_result][0]
 
     # ------------------- PREPARE CREATING THE OEMOF MODEL -------------------
 
@@ -149,7 +149,7 @@ class Component:
 
     # ------------------- UPDATE STATES -------------------
 
-    def update_states(self, results, sim_params):
+    def update_states(self, results):
         """Updates the states, used as placeholder for components without states.
         If a component has states, this update_states function is overwritten in the
         specific component.
@@ -182,7 +182,7 @@ class Component:
 
     # ------------------- UPDATE THE COSTS -------------------
 
-    def update_var_costs(self, results, sim_params):
+    def update_var_costs(self, results):
         """
         Tracks the cost and artificial costs of a component for each time step.
 
@@ -200,21 +200,23 @@ class Component:
             # If this function is not overwritten in the component, then costs
             # and art. costs are not part of the component and therefore
             # set to 0.
-            self.results['variable_costs'] = [0] * sim_params.n_intervals
-            self.results['art_costs'] = [0] * sim_params.n_intervals
+            self.results['variable_costs'] = [0] * self.sim_params.n_intervals
+            self.results['art_costs'] = [0] * self.sim_params.n_intervals
 
         # Update the costs for this time step [EUR].
         if self.variable_costs is not None:
-            this_dependency_value = self.flows[self.dependency_flow_costs][sim_params.i_interval]
-            self.results['variable_costs'][sim_params.i_interval] = \
-                this_dependency_value * sim_params.interval_time/60 * self.variable_costs
+            this_dependency_value = self.flows[self.dependency_flow_costs][
+                self.sim_params.i_interval]
+            self.results['variable_costs'][self.sim_params.i_interval] = \
+                this_dependency_value * self.sim_params.interval_time / 60 * self.variable_costs
         # Update the artificial costs for this time step [EUR].
         if self.artificial_costs is not None:
-            this_dependency_value = self.flows[self.dependency_flow_costs][sim_params.i_interval]
-            self.results['art_costs'][sim_params.i_interval] = \
-                this_dependency_value * sim_params.interval_time/60 * self.artificial_costs
+            this_dependency_value = self.flows[self.dependency_flow_costs][
+                self.sim_params.i_interval]
+            self.results['art_costs'][self.sim_params.i_interval] = \
+                this_dependency_value * self.sim_params.interval_time / 60 * self.artificial_costs
 
-    def update_var_emissions(self, results, sim_params):
+    def update_var_emissions(self, results):
         """Tracks the emissions of a component for each time step.
 
         :param results: The oemof results object for the given time step
@@ -227,15 +229,15 @@ class Component:
         if 'variable_emissions' not in self.results:
             # If this function is not overwritten in the component, then
             # emissions are not part of the component and therefore set to 0.
-            self.results['variable_emissions'] = [0] * sim_params.n_intervals
+            self.results['variable_emissions'] = [0] * self.sim_params.n_intervals
 
         # Update the emissions for this time step [kg]. Before, verify if a
         # flow name is given as emission dependency.
         if self.variable_emissions is not None:
             this_dependency_value = \
-                self.flows[self.dependency_flow_emissions][sim_params.i_interval]
-            self.results['variable_emissions'][sim_params.i_interval] = \
-                this_dependency_value * sim_params.interval_time/60 * self.variable_emissions
+                self.flows[self.dependency_flow_emissions][self.sim_params.i_interval]
+            self.results['variable_emissions'][self.sim_params.i_interval] = \
+                this_dependency_value * self.sim_params.interval_time / 60 * self.variable_emissions
 
     # ------ ADD COSTS AND ARTIFICIAL COSTS TO A PARAMETER IF THEY ARE NOT NONE ------
 

--- a/smooth/components/component.py
+++ b/smooth/components/component.py
@@ -17,8 +17,6 @@ class Component:
     :type name: str
     :param life_time: lifetime of the component [a]
     :type life_time: numerical
-    :param sim_params: simulation parameters such as the interval time and interest rate
-    :type sim_params: object
     :param results: dictionary containing the main results for the component
     :type results: dict
     :param states: dictionary containing the varying states for the component
@@ -107,8 +105,6 @@ class Component:
 
         :param results: The oemof results for the given time step
         :type results: object
-        :param sim_params: The simulation parameters for the energy system (defined by user)
-        :type sim_params: object
         :param comp_name: The name of the component - while components can generate more
             than one oemof model, they sometimes need to give a custom name, defaults to None
         :type comp_name: str, optional
@@ -156,8 +152,6 @@ class Component:
 
         :param results: oemof results object for the given time step
         :type results: object
-        :param sim_params: simulation parameters for the energy system (defined by user)
-        :type sim_params: object
         :return: if used as a placeholder, nothing will be returned. Else, refer to
             specific component that uses the update_states function for further detail.
         """
@@ -188,8 +182,6 @@ class Component:
 
         :param results: The oemof results object for the given time step
         :type results: object
-        :param sim_params: The simulation parameters for the energy system (defined by user)
-        :type sim_params: object
         :return: New values for the updated variable and artificial costs stored in
             results['variable_costs'] and results['art_costs'] respectively
         """
@@ -221,8 +213,6 @@ class Component:
 
         :param results: The oemof results object for the given time step
         :type results: object
-        :param sim_params: The simulation parameters for the energy system (defined by user)
-        :type sim_params: object
         :return: A new value for the updated emissions stored in results['variable_emissions']
         """
         # First create an empty emission array for this component, if it hasn't been created before.

--- a/smooth/components/component.py
+++ b/smooth/components/component.py
@@ -17,6 +17,8 @@ class Component:
     :type name: str
     :param life_time: lifetime of the component [a]
     :type life_time: numerical
+    :param sim_params: simulation parameters such as the interval time and interest rate
+    :type sim_params: object
     :param results: dictionary containing the main results for the component
     :type results: dict
     :param states: dictionary containing the varying states for the component

--- a/smooth/components/component_battery.py
+++ b/smooth/components/component_battery.py
@@ -214,12 +214,12 @@ class Battery(Component):
         self.p_in_max = min(
             self.c_rate_charge * self.battery_capacity,
             (self.battery_capacity - self.soc * self.battery_capacity) /
-            (self.sim_params.interval_time/60)
-            ) / self.efficiency_charge
+            (self.sim_params.interval_time / 60)
+        ) / self.efficiency_charge
         self.p_out_max = min(
             self.c_rate_discharge * self.battery_capacity,
-            (self.soc * self.battery_capacity) / (self.sim_params.interval_time/60)
-            )
+            (self.soc * self.battery_capacity) / (self.sim_params.interval_time / 60)
+        )
 
     def create_oemof_model(self, busses, _):
         """Creates an oemof Generic Storage component from the information given in
@@ -247,7 +247,7 @@ class Battery(Component):
         )
         return battery
 
-    def update_states(self, results, sim_params):
+    def update_states(self, results):
         """Updates the states of the battery component for each time step
 
         :param results: oemof results for the given time step
@@ -264,7 +264,7 @@ class Battery(Component):
             if i_result[1] == "capacity":
                 if "soc" not in self.states:
                     # Initialize a.n array that tracks the state SoC
-                    self.states["soc"] = [None] * sim_params.n_intervals
+                    self.states["soc"] = [None] * self.sim_params.n_intervals
                 # Check if this result is the state of charge.
                 self.soc = df_storage[i_result][0] / self.battery_capacity
-                self.states["soc"][sim_params.i_interval] = self.soc
+                self.states["soc"][self.sim_params.i_interval] = self.soc

--- a/smooth/components/component_battery.py
+++ b/smooth/components/component_battery.py
@@ -252,8 +252,6 @@ class Battery(Component):
 
         :param results: oemof results for the given time step
         :type results: object
-        :param sim_params: simulation parameters for the energy system (defined by user)
-        :type sim_params: object
         :return: updated state values for each state in the 'state' dict
         """
         data_storage = views.node(results, self.name)

--- a/smooth/components/component_compressor_h2.py
+++ b/smooth/components/component_compressor_h2.py
@@ -241,8 +241,6 @@ class CompressorH2(Component):
 
         :param results: oemof results object for the given time step
         :type results: object
-        :param sim_params: simulation parameters for the energy system (defined by user)
-        :type sim_params: object
         :return: updated values for each state in the 'states' dict
         """
         # Update the states of the compressor

--- a/smooth/components/component_compressor_h2.py
+++ b/smooth/components/component_compressor_h2.py
@@ -236,7 +236,7 @@ class CompressorH2(Component):
         # Convert specific compression work into electrical energy needed per kg H2 [Wh]
         self.spec_compression_energy = float(spec_compression_work / 3.6)
 
-    def update_states(self, results, sim_params):
+    def update_states(self, results):
         """Updates the states in the compressor component
 
         :param results: oemof results object for the given time step
@@ -249,7 +249,7 @@ class CompressorH2(Component):
 
         # If the states dict of this object wasn't created yet, it's done here.
         if 'specific_compression_work' not in self.states:
-            self.states['specific_compression_work'] = [None] * sim_params.n_intervals
+            self.states['specific_compression_work'] = [None] * self.sim_params.n_intervals
 
-        self.states['specific_compression_work'][sim_params.i_interval] \
+        self.states['specific_compression_work'][self.sim_params.i_interval] \
             = self.spec_compression_energy

--- a/smooth/components/component_electrolyzer.py
+++ b/smooth/components/component_electrolyzer.py
@@ -562,8 +562,6 @@ class Electrolyzer (Component):
 
         :param results: oemof results for the given time step
         :type results: object
-        :param sim_params: simulation parameters for the energy system (defined by user)
-        :type sim_params: object
         :return: updated state values for each state in the 'state' dict
         """
         # If the states dict of this object wasn't created yet, it's done here.

--- a/smooth/components/component_electrolyzer.py
+++ b/smooth/components/component_electrolyzer.py
@@ -195,7 +195,7 @@ class Electrolyzer (Component):
         # Interval time [min].
         self.interval_time = self.sim_params.interval_time
         # Calculate the max. energy the electrolyzer can use in one time step [Wh].
-        self.energy_max = self.power_max * self.interval_time/60
+        self.energy_max = self.power_max * self.interval_time / 60
 
         # ------------------- CONSTANT PARAMETERS (PHYSICS) -------------------
         # Faraday constant F [As/mol].
@@ -222,7 +222,7 @@ class Electrolyzer (Component):
         self.z_cell = 1
         is_z_cell_found = False
         while not is_z_cell_found:
-            this_curr_den = self.get_electricity_by_power(self.power_max/1000, self.temp_max)
+            this_curr_den = self.get_electricity_by_power(self.power_max / 1000, self.temp_max)
 
             if this_curr_den is not None and this_curr_den < self.cur_dens_max:
                 is_z_cell_found = True
@@ -370,7 +370,7 @@ class Electrolyzer (Component):
         # Calculate the new temperature of the electrolyzer by Newtons law of
         # cooling. The exponent (-t[s]/2310) was parameterized such that the 98 %
         # of the temperature change are reached after 2.5 hours.
-        temp_new = temp_aim + (temp_before - temp_aim) * math.exp(-self.interval_time*60 / 2310)
+        temp_new = temp_aim + (temp_before - temp_aim) * math.exp(-self.interval_time * 60 / 2310)
         # Return the new electrolyzer temperature [K].
         return temp_new
 
@@ -557,7 +557,7 @@ class Electrolyzer (Component):
 
         return voltage_reversible
 
-    def update_states(self, results, sim_params):
+    def update_states(self, results):
         """Updates the states of the electrolyser component for each time step
 
         :param results: oemof results for the given time step
@@ -568,9 +568,9 @@ class Electrolyzer (Component):
         """
         # If the states dict of this object wasn't created yet, it's done here.
         if 'temperature' not in self.states:
-            self.states['temperature'] = [None] * sim_params.n_intervals
+            self.states['temperature'] = [None] * self.sim_params.n_intervals
         if 'water_consumption' not in self.states:
-            self.states['water_consumption'] = [None] * sim_params.n_intervals
+            self.states['water_consumption'] = [None] * self.sim_params.n_intervals
 
         # Get the flows of the electrolyzer for this time step.
         data_electrolyzer = views.node(results, self.name)
@@ -595,6 +595,6 @@ class Electrolyzer (Component):
 
         # Update the current temperature and the temperature state for this time step.
         self.temperature = this_temp
-        self.states['temperature'][sim_params.i_interval] = this_temp
+        self.states['temperature'][self.sim_params.i_interval] = this_temp
         # Update the water consumption state for this time step.
-        self.states['water_consumption'][sim_params.i_interval] = this_water_consumption
+        self.states['water_consumption'][self.sim_params.i_interval] = this_water_consumption

--- a/smooth/components/component_electrolyzer_waste_heat.py
+++ b/smooth/components/component_electrolyzer_waste_heat.py
@@ -499,7 +499,7 @@ class ElectrolyzerWasteHeat(Electrolyzer):
                 po.Constraint(model_to_solve.TIMESTEPS, rule=electrolyzer_ratio_rule)
                 )
 
-    def update_flows(self, results, sim_params):
+    def update_flows(self, results):
         """Updates the flows of the electrolyser waste heat components for each time
         step.
 
@@ -510,7 +510,7 @@ class ElectrolyzerWasteHeat(Electrolyzer):
         :return: updated flow values for each flow in the 'flows' dict
         """
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.
-        Electrolyzer.update_flows(self, results, sim_params, self.name)
+        Electrolyzer.update_flows(self, results, self.name)
         Electrolyzer.update_flows(
-            self, results, sim_params, self.name + "_thermal"
+            self, results, self.name + "_thermal"
         )

--- a/smooth/components/component_electrolyzer_waste_heat.py
+++ b/smooth/components/component_electrolyzer_waste_heat.py
@@ -505,8 +505,6 @@ class ElectrolyzerWasteHeat(Electrolyzer):
 
         :param results: oemof results for the given time step
         :type results: object
-        :param sim_params: simulation parameters for the energy system (defined by user)
-        :type sim_params: object
         :return: updated flow values for each flow in the 'flows' dict
         """
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.

--- a/smooth/components/component_electrolyzer_waste_heat.py
+++ b/smooth/components/component_electrolyzer_waste_heat.py
@@ -508,7 +508,7 @@ class ElectrolyzerWasteHeat(Electrolyzer):
         :return: updated flow values for each flow in the 'flows' dict
         """
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.
-        Electrolyzer.update_flows(self, results, self.name)
+        Electrolyzer.update_flows(self, results)
         Electrolyzer.update_flows(
             self, results, self.name + "_thermal"
         )

--- a/smooth/components/component_fuel_cell_chp.py
+++ b/smooth/components/component_fuel_cell_chp.py
@@ -327,8 +327,6 @@ class FuelCellChp(Component):
 
         :param results: The oemof results for the given time step
         :type results: object
-        :param sim_params: The simulation parameters for the energy system (defined by user)
-        :type sim_params: object
         :return: updated flow values for each flow in the 'flows' dict
         """
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.

--- a/smooth/components/component_fuel_cell_chp.py
+++ b/smooth/components/component_fuel_cell_chp.py
@@ -264,7 +264,7 @@ class FuelCellChp(Component):
 
         # First create the electrical oemof component.
         fuel_cell_chp_electric = solph.custom.PiecewiseLinearTransformer(
-            label=self.name+'_electric',
+            label=self.name + '_electric',
             inputs={busses[self.bus_h2]: flow_electric},
             outputs={busses[self.bus_el]: solph.Flow()},
             in_breakpoints=self.bp_h2_consumed_el_half,
@@ -273,7 +273,7 @@ class FuelCellChp(Component):
 
         # Then create the thermal oemof component.
         fuel_cell_chp_thermal = solph.custom.PiecewiseLinearTransformer(
-            label=self.name+'_thermal',
+            label=self.name + '_thermal',
             inputs={busses[self.bus_h2]: flow_thermal},
             outputs={busses[self.bus_th]: solph.Flow()},
             in_breakpoints=self.bp_h2_consumed_th_half,
@@ -322,7 +322,7 @@ class FuelCellChp(Component):
                 po.Constraint(model_to_solve.TIMESTEPS, rule=chp_ratio_rule)
                 )
 
-    def update_flows(self, results, sim_params):
+    def update_flows(self, results):
         """Updates the flows of the fuel cell CHP components for each time step.
 
         :param results: The oemof results for the given time step
@@ -332,5 +332,5 @@ class FuelCellChp(Component):
         :return: updated flow values for each flow in the 'flows' dict
         """
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.
-        Component.update_flows(self, results, sim_params, self.name + '_electric')
-        Component.update_flows(self, results, sim_params, self.name + '_thermal')
+        Component.update_flows(self, results, self.name + '_electric')
+        Component.update_flows(self, results, self.name + '_thermal')

--- a/smooth/components/component_gas_engine_chp_biogas.py
+++ b/smooth/components/component_gas_engine_chp_biogas.py
@@ -390,8 +390,6 @@ class GasEngineChpBiogas(Component):
 
         :param results: The oemof results for the given time step
         :type results: object
-        :param sim_params: The simulation parameters for the energy system (defined by user)
-        :type sim_params: object
         :return: updated flow values for each flow in the 'flows' dict
         """
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.

--- a/smooth/components/component_gas_engine_chp_biogas.py
+++ b/smooth/components/component_gas_engine_chp_biogas.py
@@ -222,7 +222,7 @@ class GasEngineChpBiogas(Component):
         # the LHV of CH4
         self.heating_value_bg = ((self.ch4_share * self.mol_mass_ch4) /
                                  ((self.ch4_share * self.mol_mass_ch4) +
-                                  (self.co2_share*self.mol_mass_co2))) * self.heating_value_ch4
+                                  (self.co2_share * self.mol_mass_co2))) * self.heating_value_ch4
 
         # The CHP an electrical efficiency and a thermal efficiency
         # Source: 2G Energy AG Technical specification agenitor 206 BG,
@@ -328,7 +328,7 @@ class GasEngineChpBiogas(Component):
 
         # First create the electrical oemof component.
         gas_engine_chp_biogas_electric = solph.custom.PiecewiseLinearTransformer(
-            label=self.name+'_electric',
+            label=self.name + '_electric',
             inputs={busses[self.bus_bg]: flow_electric},
             outputs={busses[self.bus_el]: solph.Flow()},
             in_breakpoints=self.bp_bg_consumed_el_half,
@@ -337,7 +337,7 @@ class GasEngineChpBiogas(Component):
 
         # Then create the thermal oemof component.
         gas_engine_chp_biogas_thermal = solph.custom.PiecewiseLinearTransformer(
-            label=self.name+'_thermal',
+            label=self.name + '_thermal',
             inputs={busses[self.bus_bg]: flow_thermal},
             outputs={busses[self.bus_th]: solph.Flow()},
             in_breakpoints=self.bp_bg_consumed_th_half,
@@ -385,7 +385,7 @@ class GasEngineChpBiogas(Component):
                 po.Constraint(model_to_solve.TIMESTEPS, rule=chp_ratio_rule_methane)
                 )
 
-    def update_flows(self, results, sim_params):
+    def update_flows(self, results):
         """Updates the flows of the biogas CHP components for each time step.
 
         :param results: The oemof results for the given time step
@@ -395,5 +395,5 @@ class GasEngineChpBiogas(Component):
         :return: updated flow values for each flow in the 'flows' dict
         """
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.
-        Component.update_flows(self, results, sim_params, self.name + '_electric')
-        Component.update_flows(self, results, sim_params, self.name + '_thermal')
+        Component.update_flows(self, results, self.name + '_electric')
+        Component.update_flows(self, results, self.name + '_thermal')

--- a/smooth/components/component_h2_chp.py
+++ b/smooth/components/component_h2_chp.py
@@ -186,7 +186,7 @@ class H2Chp(Component):
 
         # First create the electrical oemof component.
         h2_chp_electric = solph.custom.PiecewiseLinearTransformer(
-            label=self.name+'_electric',
+            label=self.name + '_electric',
             inputs={busses[self.bus_h2]: flow_electric},
             outputs={busses[self.bus_el]: solph.Flow()},
             in_breakpoints=self.bp_h2_consumed_electric_half,
@@ -195,7 +195,7 @@ class H2Chp(Component):
 
         # Then create the thermal oemof component.
         h2_chp_thermal = solph.custom.PiecewiseLinearTransformer(
-            label=self.name+'_thermal',
+            label=self.name + '_thermal',
             inputs={busses[self.bus_h2]: flow_thermal},
             outputs={busses[self.bus_th]: solph.Flow()},
             in_breakpoints=self.bp_h2_consumed_thermal_half,
@@ -241,7 +241,7 @@ class H2Chp(Component):
                 po.Constraint(model_to_solve.TIMESTEPS, rule=chp_ratio_rule)
                 )
 
-    def update_flows(self, results, sim_params):
+    def update_flows(self, results):
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.
-        Component.update_flows(self, results, sim_params, self.name + '_electric')
-        Component.update_flows(self, results, sim_params, self.name + '_thermal')
+        Component.update_flows(self, results, self.name + '_electric')
+        Component.update_flows(self, results, self.name + '_thermal')

--- a/smooth/components/component_h2_refuel_cooling_system.py
+++ b/smooth/components/component_h2_refuel_cooling_system.py
@@ -105,7 +105,7 @@ class H2RefuelCoolingSystem(Component):
                                         self.csv_separator, self.column_title)
 
         self.electrical_energy = \
-            (self.data*self.cool_spec_energy + self.standby_energy) / 3.6
+            (self.data * self.cool_spec_energy + self.standby_energy) / 3.6
 
     def create_oemof_model(self, busses, _):
         """Creates an oemof Sink component from information given in

--- a/smooth/components/component_pem_electrolyzer.py
+++ b/smooth/components/component_pem_electrolyzer.py
@@ -329,8 +329,6 @@ class PemElectrolyzer(Component):
 
         ::param results: The oemof results for the given time step
         :type results: object
-        :param sim_params: The simulation parameters for the energy system (defined by user)
-        :type sim_params: object
         :return: updated flow values for each flow in the 'flows' dict
         """
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.

--- a/smooth/components/component_pem_electrolyzer.py
+++ b/smooth/components/component_pem_electrolyzer.py
@@ -324,7 +324,7 @@ class PemElectrolyzer(Component):
                 po.Constraint(model_to_solve.TIMESTEPS, rule=electrolyzer_ratio_rule)
                 )
 
-    def update_flows(self, results, sim_params):
+    def update_flows(self, results):
         """Updates the flows of the electrolyzer components for each time step.
 
         ::param results: The oemof results for the given time step
@@ -334,5 +334,5 @@ class PemElectrolyzer(Component):
         :return: updated flow values for each flow in the 'flows' dict
         """
         # Check if the component has an attribute 'flows', if not, create it as an empty dict.
-        Component.update_flows(self, results, sim_params, self.name + '_h2_prod')
-        Component.update_flows(self, results, sim_params, self.name + '_waste_heat')
+        Component.update_flows(self, results, self.name + '_h2_prod')
+        Component.update_flows(self, results, self.name + '_waste_heat')

--- a/smooth/components/component_storage_h2.py
+++ b/smooth/components/component_storage_h2.py
@@ -274,7 +274,7 @@ class StorageH2 (Component):
             balanced=False)
         return storage
 
-    def update_states(self, results, sim_params):
+    def update_states(self, results):
         """Updates the states of the storage component for each time step
 
         :param results: oemof results for the given time step
@@ -291,14 +291,14 @@ class StorageH2 (Component):
             if i_result[1] == 'capacity':
                 if 'storage_level' not in self.states:
                     # Initialize an array that tracks the state stored mass.
-                    self.states['storage_level'] = [None] * sim_params.n_intervals
-                    self.states['pressure'] = [None] * sim_params.n_intervals
+                    self.states['storage_level'] = [None] * self.sim_params.n_intervals
+                    self.states['pressure'] = [None] * self.sim_params.n_intervals
                 # Check if this result is the storage capacity.
                 self.storage_level = df_storage[i_result][0]
-                self.states['storage_level'][sim_params.i_interval] = self.storage_level
+                self.states['storage_level'][self.sim_params.i_interval] = self.storage_level
                 # Get the storage pressure [bar].
                 self.pressure = self.get_pressure(self.storage_level)
-                self.states['pressure'][sim_params.i_interval] = self.pressure
+                self.states['pressure'][self.sim_params.i_interval] = self.pressure
 
     def get_mass(self, p, V=None):
         """Calculates the mass of the storage at a certain pressure.

--- a/smooth/components/component_storage_h2.py
+++ b/smooth/components/component_storage_h2.py
@@ -279,8 +279,6 @@ class StorageH2 (Component):
 
         :param results: oemof results for the given time step
         :type results: object
-        :param sim_params: simulation parameters for the energy system (defined by user)
-        :type sim_params: object
         :return: updated state values for each state in the 'state' dict
         """
         data_storage = views.node(results, self.name)

--- a/smooth/components/component_stratified_thermal_storage.py
+++ b/smooth/components/component_stratified_thermal_storage.py
@@ -210,7 +210,6 @@ class StratifiedThermalStorage (Component):
         # parameters and the environmental temperature timeseries
         [self.loss_rate, self.fixed_losses_relative, self.fixed_losses_absolute] \
             = self.calculate_losses(
-            self.sim_params,
             self.u_value,
             self.diameter,
             self.density,
@@ -263,7 +262,7 @@ class StratifiedThermalStorage (Component):
             balanced=False)
         return thermal_storage
 
-    def update_states(self, results, sim_params):
+    def update_states(self, results):
         """Updates the states of the thermal storage component for each time step
 
         :param results: oemof results for the given time step
@@ -280,10 +279,10 @@ class StratifiedThermalStorage (Component):
             if i_result[1] == 'capacity':
                 if 'storage_level' not in self.states:
                     # Initialize an array that tracks the state stored mass.
-                    self.states['storage_level'] = [None] * sim_params.n_intervals
+                    self.states['storage_level'] = [None] * self.sim_params.n_intervals
                 # Check if this result is the storage capacity.
                 self.storage_level = df_storage[i_result][0]
-                self.states['storage_level'][sim_params.i_interval] = self.storage_level
+                self.states['storage_level'][self.sim_params.i_interval] = self.storage_level
 
     def get_volume(self, s_c, h_c, de, t_h, t_c):
         """Calculates the storage tank volume
@@ -333,7 +332,7 @@ class StratifiedThermalStorage (Component):
         u_value = 1 / denominator
         return u_value
 
-    def calculate_losses(self, sim_params, u_val, d, de, h_c, t_c, t_h, t_env, time_increment=1):
+    def calculate_losses(self, u_val, d, de, h_c, t_c, t_h, t_env, time_increment=1):
         """Calculates the loss rate and the fixed losses for the stratified thermal storage
 
         :param sim_params: simulation parameters for the energy system (defined by user)
@@ -364,7 +363,7 @@ class StratifiedThermalStorage (Component):
         # check to see if t_env is a single value or a timeseries
         if isinstance(t_env, int) is True or isinstance(t_env, float) is True:
             # if t_env is a single value, convert into a list
-            t_env = [t_env] * sim_params.n_intervals
+            t_env = [t_env] * self.sim_params.n_intervals
 
         fixed_losses_relative = [4 * u_val * (t_c - this_t_env)
                                  * 1 / ((d * de * h_c) * (t_h - t_c))

--- a/smooth/components/component_stratified_thermal_storage.py
+++ b/smooth/components/component_stratified_thermal_storage.py
@@ -267,8 +267,6 @@ class StratifiedThermalStorage (Component):
 
         :param results: oemof results for the given time step
         :type results: object
-        :param sim_params: simulation parameters for the energy system (defined by user)
-        :type sim_params: object
         :return: updated state values for each state in the 'state' dict
         """
         data_storage = views.node(results, self.name)
@@ -335,8 +333,6 @@ class StratifiedThermalStorage (Component):
     def calculate_losses(self, u_val, d, de, h_c, t_c, t_h, t_env, time_increment=1):
         """Calculates the loss rate and the fixed losses for the stratified thermal storage
 
-        :param sim_params: simulation parameters for the energy system (defined by user)
-        :type sim_params: object
         :param u_val: thermal transmittance [W/(m2*K)]
         :type u_val: numerical
         :param d: diameter of storage tank [m]

--- a/smooth/components/component_trailer_gate.py
+++ b/smooth/components/component_trailer_gate.py
@@ -90,7 +90,8 @@ class TrailerGate(Component):
             self.flow_switch = [0] * self.sim_params.n_intervals
 
         if self.variable_costs is not None:
-            this_dependency_value = self.flows[self.dependency_flow_costs][self.sim_params.i_interval]
+            this_dependency_value = self.flows[self.dependency_flow_costs][
+                self.sim_params.i_interval]
             if this_dependency_value > 0:
                 flow_switch_value = 1
             else:

--- a/smooth/components/component_trailer_gate.py
+++ b/smooth/components/component_trailer_gate.py
@@ -72,8 +72,7 @@ class TrailerGate(Component):
         # ------------------- STATES -------------------
         self.flow_switch = None
 
-
-    def update_var_costs(self, results, sim_params):
+    def update_var_costs(self, results):
         """Calculates variable costs of the component which only applies if the
         trailer is used, based on the distance travelled by the trailer.
 
@@ -87,27 +86,27 @@ class TrailerGate(Component):
         if 'variable_costs' not in self.results:
             # If this function is not overwritten in the component, then costs and art. costs are
             # not part of the component and therefore set to 0.
-            self.results['variable_costs'] = [0] * sim_params.n_intervals
-            self.results['art_costs'] = [0] * sim_params.n_intervals
+            self.results['variable_costs'] = [0] * self.sim_params.n_intervals
+            self.results['art_costs'] = [0] * self.sim_params.n_intervals
             # A list is created for the flow switch values
-            self.flow_switch = [0] * sim_params.n_intervals
+            self.flow_switch = [0] * self.sim_params.n_intervals
 
         if self.variable_costs is not None:
-            this_dependency_value = self.flows[self.dependency_flow_costs][sim_params.i_interval]
+            this_dependency_value = self.flows[self.dependency_flow_costs][self.sim_params.i_interval]
             if this_dependency_value > 0:
                 flow_switch_value = 1
             else:
                 flow_switch_value = 0
-            self.flow_switch[sim_params.i_interval] = flow_switch_value
-            self.results['variable_costs'][sim_params.i_interval] = \
+            self.flow_switch[self.sim_params.i_interval] = flow_switch_value
+            self.results['variable_costs'][self.sim_params.i_interval] = \
                 flow_switch_value * self.round_trip_distance * self.variable_costs + \
                 flow_switch_value * self.driver_costs
 
             # Update the artificial costs for this time step [EUR].
             if self.artificial_costs is not None:
                 this_dependency_value = \
-                    self.flows[self.dependency_flow_costs][sim_params.i_interval]
-                self.results['art_costs'][sim_params.i_interval] = \
+                    self.flows[self.dependency_flow_costs][self.sim_params.i_interval]
+                self.results['art_costs'][self.sim_params.i_interval] = \
                     this_dependency_value * self.artificial_costs
 
     def prepare_simulation(self, components):

--- a/smooth/components/component_trailer_gate.py
+++ b/smooth/components/component_trailer_gate.py
@@ -78,8 +78,6 @@ class TrailerGate(Component):
 
         :param results: oemof results object for this timestep
         :type results: object
-        :param sim_params: simulation parameters defined by user
-        :type sim_params: object
         """
         # First create an empty cost and art. cost array for this component, if it hasn't been
         # created before.

--- a/smooth/components/component_trailer_h2_delivery.py
+++ b/smooth/components/component_trailer_h2_delivery.py
@@ -158,12 +158,12 @@ class TrailerH2Delivery(Component):
                 fs_origin_storage_levels.append(this_origin_storage_level)
 
             # Obtains a list of the origin minimum storage levels for n sites
-            for i in index_list[n:2*n]:
+            for i in index_list[n:2 * n]:
                 this_min_storage_level = self.get_foreign_state_value(components, index=i)
                 fs_origin_min_storage_levels.append(this_min_storage_level)
 
             # Obtains a list of the origin capacity levels for n sites
-            for i in index_list[2*n:3*n]:
+            for i in index_list[2 * n:3 * n]:
                 this_capacity = self.get_foreign_state_value(components, index=i)
                 fs_origin_capacities.append(this_capacity)
 

--- a/smooth/components/component_trailer_h2_delivery_single.py
+++ b/smooth/components/component_trailer_h2_delivery_single.py
@@ -142,7 +142,7 @@ class TrailerH2DeliverySingle(Component):
             # Obtains the available mass that can be taken from the origin storage [kg]
             fs_origin_available_kg_1 = min((fs_origin_storage_level_kg_1 -
                                             fs_origin_min_storage_level_1),
-                                           fs_origin_capacity_1/2)
+                                           fs_origin_capacity_1 / 2)
 
             # Get the availability mass of hydrogen of the fullest origin storage
             self.fs_origin_available_kg = fs_origin_available_kg_1

--- a/smooth/components/external_component.py
+++ b/smooth/components/external_component.py
@@ -35,6 +35,8 @@ class ExternalComponent:
     :type name: str
     :param life_time: lifetime of the external component [a]
     :type life_time: numerical
+    :param sim_params: simulation parameters such as the interval time and interest rate
+    :type sim_params: object
     :param results: dictionary containing the main results for the component
     :type results: dict
     :param capex: capital costs

--- a/smooth/components/external_component.py
+++ b/smooth/components/external_component.py
@@ -35,8 +35,6 @@ class ExternalComponent:
     :type name: str
     :param life_time: lifetime of the external component [a]
     :type life_time: numerical
-    :param sim_params: simulation parameters such as the interval time and interest rate
-    :type sim_params: object
     :param results: dictionary containing the main results for the component
     :type results: dict
     :param capex: capital costs

--- a/smooth/components/external_component_h2_dispenser.py
+++ b/smooth/components/external_component_h2_dispenser.py
@@ -110,8 +110,8 @@ class H2Dispenser(ExternalComponent):
 
         # ------------------- CALCULATED PARAMETERS -------------------
         self.max_hourly_h2_demand = self.data.values.max()
-        self.number_of_refuels_per_hour = 60/self.refuelling_time
-        self.max_number_of_vehicles = self.max_hourly_h2_demand/self.vehicle_tank_size
+        self.number_of_refuels_per_hour = 60 / self.refuelling_time
+        self.max_number_of_vehicles = self.max_hourly_h2_demand / self.vehicle_tank_size
         self.number_of_units =\
-            ceil(self.max_number_of_vehicles/(self.number_of_hoses *
-                                              self.number_of_refuels_per_hour))
+            ceil(self.max_number_of_vehicles / (self.number_of_hoses *
+                                                self.number_of_refuels_per_hour))

--- a/smooth/framework/run_smooth.py
+++ b/smooth/framework/run_smooth.py
@@ -232,13 +232,13 @@ def run_smooth(model):
         # Loop through every component and call the result handling functions
         for this_comp in components:
             # Update the flows
-            this_comp.update_flows(results, sim_params)
+            this_comp.update_flows(results)
             # Update the states.
-            this_comp.update_states(results, sim_params)
+            this_comp.update_states(results)
             # Update the costs and artificial costs.
-            this_comp.update_var_costs(results, sim_params)
+            this_comp.update_var_costs(results)
             # Update the costs and artificial costs.
-            this_comp.update_var_emissions(results, sim_params)
+            this_comp.update_var_emissions(results)
 
     # Calculate the annuity for each component.
     for this_comp in components:


### PR DESCRIPTION
This PR replaces former outdated PR #209
- within all components replace sim_params by self.sim_params
- remove sim_params as additional parameter of update functions
- incorporate remark from PR #209
- make flake happy

skript executed within component folder:
for f in *.py; do 
	sed -i 's/sim_params/self.sim_params/g' $f;
	sed -i 's/self.self.sim_params/self.sim_params/g' $f;
	sed -i 's/param self.sim_params/param sim_params/g' $f;
	sed -i 's/type self.sim_params/type sim_params/g' $f;
	sed -i 's/, self.sim_params//g' $f;
	sed -i 's/self.sim_params,//g' $f;
	sed -i '/sim_params:/d' $f;
done
autopep8 -i --max-line-length 100 -a -a *

