### PR TITLE
set input params of AC/DC converter on init

### DIFF
--- a/smooth/components/component_ac_dc_converter.py
+++ b/smooth/components/component_ac_dc_converter.py
@@ -72,6 +72,8 @@ class ACDCConverter(Component):
         # The efficiency of an AC-DC converter
         self.efficiency = 0.95
 
+        self.set_parameters(params)
+
     def create_oemof_model(self, busses, _):
         """Creates an oemof Transformer component using the information given in
         the ACDCConverter class, to be used in the oemof model

--- a/smooth/components/component_dc_ac_inverter.py
+++ b/smooth/components/component_dc_ac_inverter.py
@@ -60,6 +60,8 @@ class DCACInverter(Component):
         self.output_power_max = 150000
         self.efficiency = 0.99
 
+        self.set_parameters(params)
+
     def create_oemof_model(self, busses, _):
         """Creates a simple oemof Transformer component using the information
         given in the DCACInverter class, to be used in the oemof model


### PR DESCRIPTION
Given input parameter of AC/DC converter was not set during instance creation, making it use only the default parameters. Model creation was impossible.