### PR TITLE
removed unecessary results input param from function

### DIFF
--- a/smooth/components/component.py
+++ b/smooth/components/component.py
@@ -178,12 +178,10 @@ class Component:
 
     # ------------------- UPDATE THE COSTS -------------------
 
-    def update_var_costs(self, results):
+    def update_var_costs(self):
         """
         Tracks the cost and artificial costs of a component for each time step.
 
-        :param results: The oemof results object for the given time step
-        :type results: object
         :return: New values for the updated variable and artificial costs stored in
             results['variable_costs'] and results['art_costs'] respectively
         """
@@ -210,11 +208,9 @@ class Component:
             self.results['art_costs'][self.sim_params.i_interval] = \
                 this_dependency_value * self.sim_params.interval_time / 60 * self.artificial_costs
 
-    def update_var_emissions(self, results):
+    def update_var_emissions(self):
         """Tracks the emissions of a component for each time step.
 
-        :param results: The oemof results object for the given time step
-        :type results: object
         :return: A new value for the updated emissions stored in results['variable_emissions']
         """
         # First create an empty emission array for this component, if it hasn't been created before.

--- a/smooth/components/component_trailer_gate.py
+++ b/smooth/components/component_trailer_gate.py
@@ -72,12 +72,9 @@ class TrailerGate(Component):
         # ------------------- STATES -------------------
         self.flow_switch = None
 
-    def update_var_costs(self, results):
+    def update_var_costs(self):
         """Calculates variable costs of the component which only applies if the
         trailer is used, based on the distance travelled by the trailer.
-
-        :param results: oemof results object for this timestep
-        :type results: object
         """
         # First create an empty cost and art. cost array for this component, if it hasn't been
         # created before.

--- a/smooth/framework/run_smooth.py
+++ b/smooth/framework/run_smooth.py
@@ -236,9 +236,9 @@ def run_smooth(model):
             # Update the states.
             this_comp.update_states(results)
             # Update the costs and artificial costs.
-            this_comp.update_var_costs(results)
+            this_comp.update_var_costs()
             # Update the costs and artificial costs.
-            this_comp.update_var_emissions(results)
+            this_comp.update_var_emissions()
 
     # Calculate the annuity for each component.
     for this_comp in components:


### PR DESCRIPTION
removed unused 'results' input parameter from:

- Generic component (update_var_costs and update_var_emissions functions)
- Trailer gate component (update_var_costs function)
- Run smooth function (instances of the update_var_costs and update_var_emissions functions)