### PR TITLE
add blocking to show plot in order to plot busses individually

### DIFF
--- a/smooth/examples/run_smooth_example.py
+++ b/smooth/examples/run_smooth_example.py
@@ -39,9 +39,9 @@ from smooth.examples.example_plotting_dicts import comp_dict_german
 if __name__ == '__main__':
     # Run an example.
     smooth_result, status = run_smooth(mymodel)
-    plot_smooth_results(smooth_result, comp_dict_german)
     print_smooth_results(smooth_result)
-    save_results('example_results', smooth_result)
     external_components = costs_for_ext_components(mymodel)
+    plot_smooth_results(smooth_result, comp_dict_german)
+    save_results('example_results', smooth_result)
 
     print('done')

--- a/smooth/framework/functions/plot_results.py
+++ b/smooth/framework/functions/plot_results.py
@@ -50,4 +50,4 @@ def plot_smooth_results(smooth_result, comp_label_dict=comp_dict_german,
         except KeyError:
             plt.title('bus: ' + this_bus)
             # no label for y axis
-    plt.show(block=True)
+    plt.show(block=False)

--- a/smooth/framework/functions/plot_results.py
+++ b/smooth/framework/functions/plot_results.py
@@ -50,4 +50,4 @@ def plot_smooth_results(smooth_result, comp_label_dict=comp_dict_german,
             plt.title('bus: ' + this_bus)
             # no label for y axis
 
-        plt.show()
+        plt.show(block=True)

--- a/smooth/framework/functions/plot_results.py
+++ b/smooth/framework/functions/plot_results.py
@@ -37,6 +37,7 @@ def plot_smooth_results(smooth_result, comp_label_dict=comp_dict_german,
 
     # Plot each bus in a new window.
     for this_bus in busses_to_plot:
+        plt.figure()
         for this_component, this_flow in busses_to_plot[this_bus].items():
             # get time axis (in hours, interval_time is in minutes)
             timeseries = [sim_params.interval_time/60 * t for t in range(len(this_flow))]
@@ -49,5 +50,4 @@ def plot_smooth_results(smooth_result, comp_label_dict=comp_dict_german,
         except KeyError:
             plt.title('bus: ' + this_bus)
             # no label for y axis
-
-        plt.show(block=True)
+    plt.show(block=True)


### PR DESCRIPTION
When an interactive backend is used in Matplotlib, the plt.show() does not prevent the program from continuing, you have to add 
plt.show(block=True)

https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.pyplot.show.html

solves #244 