### PR TITLE
Change create_oemof_model to add_to_oemof_model for each component

### DIFF
--- a/doc/source/smooth.components.rst
+++ b/doc/source/smooth.components.rst
@@ -18,7 +18,7 @@ In order to build a component, you must do the following:
 
 #. Define any other functions that are specific to your component.
 
-#. All components built in SMOOTH must be created as oemof components to be used in the oemof model (see `oemof-solph's component list <https://oemof-solph.readthedocs.io/en/latest/usage.html#solph-components>`_ to choose the best fitting component). Then create the oemof component in the :func:`create_oemof_model` function, defining all of the necessary parameters.
+#. All components built in SMOOTH must be created as oemof components to be used in the oemof model (see `oemof-solph's component list <https://oemof-solph.readthedocs.io/en/latest/usage.html#solph-components>`_ to choose the best fitting component). Then add the component to your oemof model using the :func:`add_to_oemof_model` function, defining all of the necessary parameters.
 
 #. If the states of the component need updating after each time step, specifiy these in the :func:`update_states` function. 
 

--- a/smooth/components/component_air_source_heat_pump.py
+++ b/smooth/components/component_air_source_heat_pump.py
@@ -157,13 +157,15 @@ class AirSourceHeatPump(Component):
             # self.consider_icing,
             self.factor_icing)
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof Transformer component from information given in
         the AirSourceHeatPump class, to be used in the oemof model
 
         :param busses: virtual buses used in the energy system
         :type busses: list
-        :return: oemof 'air_source_heat_pump' component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         air_source_heat_pump = solph.Transformer(
             label=self.name,
@@ -173,4 +175,6 @@ class AirSourceHeatPump(Component):
                 variable_costs=0)},
             conversion_factors={busses[self.bus_th]: self.cops[self.sim_params.i_interval]}
         )
+
+        model.add(air_source_heat_pump)
         return air_source_heat_pump

--- a/smooth/components/component_battery.py
+++ b/smooth/components/component_battery.py
@@ -54,7 +54,7 @@ the input-flow/output-flow between bus and battery needs to include the energy l
 
     P_{out,max} = P_{discharge,max} \\cdot \\mu_{discharge}
 Due to the inflow_conversion_factor / outflow_conversion_factor
-(in :func:`~smooth.components.component_battery.Battery.create_oemof_model`)
+(in :func:`~smooth.components.component_battery.Battery.add_to_oemof_model`)
 the battery will then receive right amount.
 
 * :math:`P_{charge,max}` = maximum chargeable power at the battery [W]
@@ -228,13 +228,15 @@ class Battery(Component):
         self.p_in_max = self.c_rate_charge * self.battery_capacity / self.efficiency_charge
         self.p_out_max = self.c_rate_discharge * self.battery_capacity * self.efficiency_discharge
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof Generic Storage component from the information given in
         the Battery class, to be used in the oemof model.
 
         :param busses: List of the virtual buses used in the energy system
         :type busses: list
-        :return: The 'battery' oemof component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         battery = solph.components.GenericStorage(
             label=self.name,
@@ -252,6 +254,7 @@ class Battery(Component):
             outflow_conversion_factor=self.efficiency_discharge,
             balanced=False,
         )
+        model.add(battery)
         return battery
 
     def update_states(self, results):

--- a/smooth/components/component_compressor_h2.py
+++ b/smooth/components/component_compressor_h2.py
@@ -197,13 +197,15 @@ class CompressorH2(Component):
         self.Mr_H2 = 2.016 * 1e-3
         self.R_H2 = self.R / self.Mr_H2
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof Transformer component using the information given in
         the CompressorH2 class, to be used in the oemof model
 
         :param busses: virtual buses used in the energy system
         :type busses: list
-        :return: the oemof compressor component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         compressor = solph.Transformer(
             label=self.name,
@@ -217,6 +219,7 @@ class CompressorH2(Component):
                 busses[self.bus_el]: self.spec_compression_energy,
                 busses[self.bus_h2_out]: 1})
 
+        model.add(compressor)
         return compressor
 
     def prepare_simulation(self, components):

--- a/smooth/components/component_electric_heater.py
+++ b/smooth/components/component_electric_heater.py
@@ -74,13 +74,15 @@ class ElectricHeater(Component):
         # ------------------- UPDATE PARAMETER DEFAULT VALUES -------------------
         self.set_parameters(params)
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof Transformer component from the information given in the
         ElectricHeater class, to be used in the oemof model
 
         :param busses: virtual buses used in the energy system
         :type busses: list
-        :return: 'electric_heater' oemof component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         electric_heater = solph.Transformer(
             label=self.name,
@@ -89,4 +91,5 @@ class ElectricHeater(Component):
                 nominal_value=self.power_max)},
             conversion_factors={busses[self.bus_th]: self.efficiency})
 
+        model.add(electric_heater)
         return electric_heater

--- a/smooth/components/component_electrolyzer.py
+++ b/smooth/components/component_electrolyzer.py
@@ -254,13 +254,15 @@ class Electrolyzer (Component):
         # Return the according hydrogen production value [kg].
         return self.supporting_points['h2_produced'][this_index]
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof Transformer component from the information given in the
         Electrolyzer class, to be used in the oemof model
 
         :param busses: virtual buses used in the energy system
         :type busses: list
-        :return: the oemof electrolyzer component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         # Get the non-linear behaviour.
         self.update_nonlinear_behaviour()
@@ -275,6 +277,8 @@ class Electrolyzer (Component):
             in_breakpoints=self.supporting_points['energy'],
             conversion_function=self.conversion_fun_ely,
             pw_repn='CC')
+
+        model.add(electrolyzer)
         return electrolyzer
 
     def update_nonlinear_behaviour(self):

--- a/smooth/components/component_electrolyzer_waste_heat.py
+++ b/smooth/components/component_electrolyzer_waste_heat.py
@@ -309,7 +309,7 @@ class ElectrolyzerWasteHeat(Electrolyzer):
         # Return the according hydrogen production value [kg].
         return self.supporting_points["thermal_energy"][this_index]
 
-    def create_oemof_model(self, busses, model):
+    def add_to_oemof_model(self, busses, model):
         """Creates two separate oemof Piecewise Linear Transformer components for the hydrogen
         and thermal production of the electrolyser from information given in the
         ElectrolyserWasteHeat class, to be used in the oemof model
@@ -357,8 +357,7 @@ class ElectrolyzerWasteHeat(Electrolyzer):
 
         self.model_h2 = electrolyzer
         self.model_th = electrolyzer_thermal
-
-        return None
+        return (electrolyzer, electrolyzer_thermal)
 
     def update_nonlinear_behaviour(self):
         """Updates the nonlinear behaviour of the electrolyser in terms of hydrogen and

--- a/smooth/components/component_energy_demand_from_csv.py
+++ b/smooth/components/component_energy_demand_from_csv.py
@@ -75,13 +75,15 @@ class EnergyDemandFromCsv(Component):
         self.data = func.read_data_file(self.path, self.csv_filename,
                                         self.csv_separator, self.column_title)
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof Sink component from the information given in the
         EnergyDemandFromCSV class, to be used in the oemof model.
 
         :param busses: List of the virtual buses used in the energy system
         :type busses: list
-        :return: The 'energy_demand_from_csv' oemof component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         energy_demand_from_csv = solph.Sink(
             label=self.name,
@@ -89,4 +91,6 @@ class EnergyDemandFromCsv(Component):
                 actual_value=self.data.iloc[self.sim_params.i_interval],
                 nominal_value=self.nominal_value,
                 fixed=True)})
+
+        model.add(energy_demand_from_csv)
         return energy_demand_from_csv

--- a/smooth/components/component_energy_source_from_csv.py
+++ b/smooth/components/component_energy_source_from_csv.py
@@ -74,13 +74,15 @@ class EnergySourceFromCsv (Component):
         self.data = func.read_data_file(self.path, self.csv_filename,
                                         self.csv_separator, self.column_title)
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof Source component from the information given in the
         EnergySourceFromCSV class, to be used in the oemof model.
 
         :param busses: List of the virtual buses used in the energy system
         :type busses: list
-        :return: The 'energy_source_from_csv' oemof component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         energy_source_from_csv = solph.Source(
             label=self.name,
@@ -88,4 +90,6 @@ class EnergySourceFromCsv (Component):
                 actual_value=self.data.iloc[self.sim_params.i_interval],
                 nominal_value=self.nominal_value,
                 fixed=True)})
+
+        model.add(energy_source_from_csv)
         return energy_source_from_csv

--- a/smooth/components/component_fuel_cell_chp.py
+++ b/smooth/components/component_fuel_cell_chp.py
@@ -242,7 +242,7 @@ class FuelCellChp(Component):
         this_index = self.bp_h2_consumed_th_half.index(h2_consumption)
         return self.bp_energy_th[this_index]
 
-    def create_oemof_model(self, busses, model):
+    def add_to_oemof_model(self, busses, model):
         """Creates two separate oemof Piecewise Linear Transformer components for the
         electrical and thermal production of the fuel cell CHP from information given
         in the FuelCellCHP class, to be used in the oemof model
@@ -252,7 +252,7 @@ class FuelCellChp(Component):
         :param model: oemof model containing the electrical energy production and
             thermal energy production of the fuel cell CHP
         :type model: model
-        :return: the oemof fuel cell CHP electric and thermal components
+        :return: tuple of electric and thermal oemof components
         """
         # The CHP has to be modelled as two components, while the piecewise linear
         # transformer does not accept 2 outputs yet.
@@ -285,8 +285,7 @@ class FuelCellChp(Component):
 
         self.model_el = fuel_cell_chp_electric
         self.model_th = fuel_cell_chp_thermal
-
-        return None
+        return (fuel_cell_chp_electric, fuel_cell_chp_thermal)
 
     def update_constraints(self, busses, model_to_solve):
         """Set a constraint so that the hydrogen inflow of the electrical and

--- a/smooth/components/component_gas_engine_chp_biogas.py
+++ b/smooth/components/component_gas_engine_chp_biogas.py
@@ -304,7 +304,7 @@ class GasEngineChpBiogas(Component):
         this_index = self.bp_bg_consumed_th_half.index(bg_consumption)
         return self.bp_energy_th[this_index]
 
-    def create_oemof_model(self, busses, model):
+    def add_to_oemof_model(self, busses, model):
         """Creates two separate oemof Piecewise Linear Transformer components for the
         electrical and thermal production of the biogas CHP from information given
         in the GasEngineChpBiogas class, to be used in the oemof model
@@ -314,7 +314,7 @@ class GasEngineChpBiogas(Component):
         :param model: oemof model containing the electrical energy production and
             thermal energy production of the biogas CHP
         :type model: model
-        :return: the oemof biogas CHP electric and thermal components
+        :return: tuple of electric and biogas oemof components
         """
         # Create the non-linear oemof component. The CHP has to be modelled as
         # two components, while the piecewise linear transformer does not
@@ -349,8 +349,7 @@ class GasEngineChpBiogas(Component):
 
         self.model_el = gas_engine_chp_biogas_electric
         self.model_th = gas_engine_chp_biogas_thermal
-
-        return None
+        return (gas_engine_chp_biogas_electric, gas_engine_chp_biogas_thermal)
 
     def update_constraints(self, busses, model_to_solve):
         """Set a constraint so that the biogas inflow of the electrical and

--- a/smooth/components/component_gate.py
+++ b/smooth/components/component_gate.py
@@ -59,13 +59,15 @@ class Gate(Component):
         # ------------------- UPDATE PARAMETER DEFAULT VALUES -------------------
         self.set_parameters(params)
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof Transformer component from information given in
         the Gate class, to be used in the oemof model
 
         :param busses: virtual buses used in the energy system
         :type busses: list
-        :return: oemof 'gate' component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         gate = solph.Transformer(
             label=self.name,
@@ -74,4 +76,6 @@ class Gate(Component):
             outputs={busses[self.bus_out]: solph.Flow()},
             conversion_factors={busses[self.bus_out]: self.efficiency}
         )
+
+        model.add(gate)
         return gate

--- a/smooth/components/component_h2_chp.py
+++ b/smooth/components/component_h2_chp.py
@@ -174,10 +174,18 @@ class H2Chp(Component):
         # Return the according hydrogen production value [kg].
         return self.bp_energy_thermal[this_index]
 
-    def create_oemof_model(self, busses, model):
-        # Create the non-linear oemof component. The CHP has to be modelled as
-        # two components, while the piecewise linear transformer does not
-        # accept 2 outputs yet.
+    def add_to_oemof_model(self, busses, model):
+        """Creates a non-linear oemof Transformer component to be used in the oemof model
+
+        The CHP has to be modelled as two components
+        because the piecewise linear transformer does not accept 2 outputs yet.
+
+        :param busses: virtual buses used in the energy system
+        :type busses: list
+        :param model: current oemof model
+        :type model: oemof model
+        :return: tuple of electric and thermal oemof components
+        """
 
         flow_electric = solph.Flow(
             nominal_value=self.bp_h2_consumed_electric_half[-1],
@@ -208,20 +216,7 @@ class H2Chp(Component):
         self.model_el = h2_chp_electric
         self.model_th = h2_chp_thermal
 
-        """
-        # Get the input H2 flows of both oemof components that need to be set equal.
-        flow_electric = model.nodes[len(model.nodes)-2].inputs[busses[self.bus_h2]]
-        flow_thermal = model.nodes[len(model.nodes) - 1].inputs[busses[self.bus_h2]]
-
-        # Get
-        fl_el = model.groups[self.name + '_electric'].inputs[busses[self.bus_h2]]
-        fl_th = model.groups[self.name + '_thermal'].inputs[busses[self.bus_h2]]
-        """
-        # Now set the two inflows of H2 in the electrical in the thermal CHP
-        # component to be the same.
-        # solph.constraints.equate_variables(model, flow_electric, flow_thermal)
-
-        return None
+        return (h2_chp_electric, h2_chp_thermal)
 
     def update_constraints(self, busses, model_to_solve):
         # Set a constraint so that the hydrogen inflow of the electrical and

--- a/smooth/components/component_h2_refuel_cooling_system.py
+++ b/smooth/components/component_h2_refuel_cooling_system.py
@@ -107,13 +107,15 @@ class H2RefuelCoolingSystem(Component):
         self.electrical_energy = \
             (self.data * self.cool_spec_energy + self.standby_energy) / 3.6
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof Sink component from information given in
         the H2RefuelCoolingSystem class, to be used in the oemof model
 
         :param busses: virtual buses used in the energy system
         :type busses: list
-        :return: oemof 'h2_refuel_cooling_system' component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         h2_refuel_cooling_system = solph.Sink(
             label=self.name,
@@ -122,4 +124,6 @@ class H2RefuelCoolingSystem(Component):
                     nominal_value=self.nominal_value,
                     fixed=True
                     )})
+
+        model.add(h2_refuel_cooling_system)
         return h2_refuel_cooling_system

--- a/smooth/components/component_pem_electrolyzer.py
+++ b/smooth/components/component_pem_electrolyzer.py
@@ -245,7 +245,7 @@ class PemElectrolyzer(Component):
         # Return the according waste heat energy value [Wh]
         return self.bp_waste_heat_energy[this_index]
 
-    def create_oemof_model(self, busses, model):
+    def add_to_oemof_model(self, busses, model):
         """Creates two separate oemof Piecewise Linear Transformer components for the
         hydrogen and waste heat production of the PEM electrolyzer from information
         given in the PEMElectrolyzer class, to be used in the oemof model
@@ -255,7 +255,7 @@ class PemElectrolyzer(Component):
         :param model: oemof model containing the hydrogen production and
             waste heat production of the PEM electrolyzer
         :type model: model
-        :return: the oemof PEM electrolyzer hydrogen and waste heat components
+        :return: tuple of H2 and waste heat oemof components
         """
         # The PEM electrolyzer has to be modelled as two components, while the
         # piecewise linear transformer does not accept 2 outputs yet.
@@ -289,7 +289,7 @@ class PemElectrolyzer(Component):
         self.model_h2 = pem_electrolyzer_h2_prod
         self.model_th = pem_electrolyzer_waste_heat
 
-        return None
+        return (pem_electrolyzer_h2_prod, pem_electrolyzer_waste_heat)
 
     def update_constraints(self, busses, model_to_solve):
         """Set a constraint so that the electricity inflow of the hydrogen and

--- a/smooth/components/component_power_converter.py
+++ b/smooth/components/component_power_converter.py
@@ -76,13 +76,15 @@ class PowerConverter(Component):
 
         self.set_parameters(params)
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof Transformer component using the information given in
         the PowerConverter class, to be used in the oemof model
 
         :param busses: virtual buses used in the energy system
         :type busses: dict
-        :return: the oemof power_converter component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         power_converter = solph.Transformer(
             label=self.name,
@@ -91,4 +93,6 @@ class PowerConverter(Component):
                 nominal_value=self.output_power_max
             )},
             conversion_factors={busses[self.bus_output]: self.efficiency})
+
+        model.add(power_converter)
         return power_converter

--- a/smooth/components/component_sink.py
+++ b/smooth/components/component_sink.py
@@ -55,13 +55,15 @@ class Sink(Component):
         # ------------------- COSTS -------------------
         self.commodity_costs = self.get_costs_and_art_costs()
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof Sink component from the information given in the Sink
         class, to be used in the oemof model.
 
         :param busses: List of the virtual buses used in the energy system
         :type busses: list
-        :return: 'sink' oemof component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         sink = solph.Sink(
             label=self.name,
@@ -69,4 +71,6 @@ class Sink(Component):
                 variable_costs=self.commodity_costs,
                 nominal_value=self.input_max
             )})
+
+        model.add(sink)
         return sink

--- a/smooth/components/component_storage_h2.py
+++ b/smooth/components/component_storage_h2.py
@@ -254,13 +254,15 @@ class StorageH2 (Component):
         self.current_vac = [vac_in, vac_out]
         self.delta_max = self.storage_capacity
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof Generic Storage component from the information given in
         the StorageH2 class, to be used in the oemof model.
 
         :param busses: List of the virtual buses used in the energy system
         :type busses: list
-        :return: The 'storage' oemof component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         storage = solph.components.GenericStorage(
             label=self.name,
@@ -272,6 +274,8 @@ class StorageH2 (Component):
             nominal_storage_capacity=self.storage_capacity,
             min_storage_level=self.storage_level_min / self.storage_capacity,
             balanced=False)
+
+        model.add(storage)
         return storage
 
     def update_states(self, results):

--- a/smooth/components/component_stratified_thermal_storage.py
+++ b/smooth/components/component_stratified_thermal_storage.py
@@ -237,13 +237,15 @@ class StratifiedThermalStorage (Component):
 
         self.current_vac = [vac_in, vac_out]
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof GenericStorage component from the information given in the
         Stratified Thermal Storage class, to be used in the oemof model
 
         :param busses: virtual buses used in the energy system
         :type busses: list
-        :return: the oemof thermal storage component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         thermal_storage = solph.components.GenericStorage(
             label=self.name,
@@ -260,6 +262,8 @@ class StratifiedThermalStorage (Component):
             inflow_conversion_factor=1,
             outflow_conversion_factor=1,
             balanced=False)
+
+        model.add(thermal_storage)
         return thermal_storage
 
     def update_states(self, results):

--- a/smooth/components/component_supply.py
+++ b/smooth/components/component_supply.py
@@ -109,13 +109,15 @@ class Supply (Component):
         # (costs + art.  costs) e.g. [EUR/Wh], [EUR/kg].
         self.current_ac = self.get_costs_and_art_costs()
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof Source component from the information given in the Supply
         class, to be used in the oemof model.
 
         :param busses: List of the virtual buses used in the energy system
         :type busses: list
-        :return: 'from_grid' oemof component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         from_grid = solph.Source(
             label=self.name,
@@ -123,4 +125,6 @@ class Supply (Component):
                 nominal_value=self.output_max,
                 variable_costs=self.current_ac
             )})
+
+        model.add(from_grid)
         return from_grid

--- a/smooth/components/component_trailer_gate.py
+++ b/smooth/components/component_trailer_gate.py
@@ -130,13 +130,15 @@ class TrailerGate(Component):
             else:
                 self.max_input = 0
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof Transformer component from the information given in the
         TrailerGate class, to be used in the oemof model.
 
         :param busses: list of the virtual buses used in the energy system
         :type busses: list
-        :return: the 'trailer_gate' oemof component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         trailer_gate = solph.Transformer(
             label=self.name,
@@ -144,4 +146,6 @@ class TrailerGate(Component):
                                                     nominal_value=self.max_input)},
             outputs={busses[self.bus_out]: solph.Flow()}
         )
+
+        model.add(trailer_gate)
         return trailer_gate

--- a/smooth/components/component_trailer_gate_cascade.py
+++ b/smooth/components/component_trailer_gate_cascade.py
@@ -68,17 +68,21 @@ class TrailerGateCascade(Component):
         if self.fs_component_name is not None:
             self.max_input = self.get_foreign_state_value(components, index=0)
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof Transformer component from the information given in the
         TrailerGateCascade class, to be used in the oemof model.
 
         :param busses: list of the virtual buses used in the energy system
         :type busses: list
-        :return: the 'trailer_gate_cascade' oemof component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         trailer_gate_cascade = solph.Transformer(
             label=self.name,
             inputs={busses[self.bus_in]: solph.Flow(nominal_value=self.max_input)},
             outputs={busses[self.bus_out]: solph.Flow()}
         )
+
+        model.add(trailer_gate_cascade)
         return trailer_gate_cascade

--- a/smooth/components/component_trailer_h2_delivery.py
+++ b/smooth/components/component_trailer_h2_delivery.py
@@ -220,16 +220,20 @@ class TrailerH2Delivery(Component):
 
         self.current_ac = self.get_costs_and_art_costs()
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof Transformer component from the information given in the
         TrailerH2Delivery class, to be used in the oemof model.
 
         :param busses: list of the virtual buses used in the energy system
         :type busses: list
-        :return: the 'trailer' oemof component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         trailer = solph.Transformer(
             label=self.name,
             outputs={busses[self.bus_out]: solph.Flow(variable_costs=self.current_ac)},
             inputs={busses[self.bus_in]: solph.Flow(nominal_value=self.hydrogen_needed)})
+
+        model.add(trailer)
         return trailer

--- a/smooth/components/component_trailer_h2_delivery_cascade.py
+++ b/smooth/components/component_trailer_h2_delivery_cascade.py
@@ -243,16 +243,20 @@ class TrailerH2DeliveryCascade(Component):
 
         self.current_ac = self.get_costs_and_art_costs()
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof Transformer component from the information given in the
         TrailerH2DeliveryCascade class, to be used in the oemof model.
 
         :param busses: list of the virtual buses used in the energy system
         :type busses: list
-        :return: the 'trailer_cascade' oemof component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         trailer_cascade = solph.Transformer(
             label=self.name,
             outputs={busses[self.bus_out]: solph.Flow(variable_costs=self.current_ac)},
             inputs={busses[self.bus_in]: solph.Flow(nominal_value=self.hydrogen_needed)})
+
+        model.add(trailer_cascade)
         return trailer_cascade

--- a/smooth/components/component_trailer_h2_delivery_single.py
+++ b/smooth/components/component_trailer_h2_delivery_single.py
@@ -187,16 +187,20 @@ class TrailerH2DeliverySingle(Component):
 
         self.current_ac = self.get_costs_and_art_costs()
 
-    def create_oemof_model(self, busses, _):
+    def add_to_oemof_model(self, busses, model):
         """Creates an oemof Transformer component from the information given in the
         TrailerH2DeliverySingle class, to be used in the oemof model.
 
         :param busses: list of the virtual buses used in the energy system
         :type busses: list
-        :return: the 'trailer_single' oemof component
+        :param model: current oemof model
+        :type model: oemof model
+        :return: oemof component
         """
         trailer_single = solph.Transformer(
             label=self.name,
             outputs={busses[self.bus_out]: solph.Flow(variable_costs=self.current_ac)},
             inputs={busses[self.bus_in]: solph.Flow(nominal_value=self.hydrogen_needed)})
+
+        model.add(trailer_single)
         return trailer_single

--- a/smooth/framework/run_smooth.py
+++ b/smooth/framework/run_smooth.py
@@ -187,14 +187,8 @@ def run_smooth(model):
         for this_comp in components:
             # Execute the prepare simulation step (if this component has one).
             this_comp.prepare_simulation(components)
-            # Get the oemof representation of this component.
-            this_oemof_model = this_comp.create_oemof_model(busses, oemof_model)
-            if this_oemof_model is not None:
-                # Add the component to the oemof model.
-                oemof_model.add(this_oemof_model)
-            else:
-                # If None is given back, no model is supposed to be added.
-                pass
+            # add oemof representation of this component to model
+            this_comp.add_to_oemof_model(busses, oemof_model)
 
         # ------------------- RUN THE SIMULATION -------------------
         # Do the simulation for this time step.

--- a/tests/test_power_converter.py
+++ b/tests/test_power_converter.py
@@ -10,16 +10,18 @@ def test_init():
     assert power_converter.output_power_max == params["output_power_max"]
 
 
-def test_create_oemof_model():
+def test_add_to_oemof_model():
     power_converter = PowerConverter({
         "bus_input": "bus_input",
         "bus_output": "bus_output"
     })
-    model = power_converter.create_oemof_model({
+    model = solph.EnergySystem()
+    comp = power_converter.add_to_oemof_model({
         "bus_input": solph.Bus(label="bus_input"),
         "bus_output": solph.Bus(label="bus_output"),
-    }, None)
+    }, model)
 
-    assert type(model) == solph.Transformer
-    assert len(model.inputs) == 1
-    assert len(model.outputs) == 1
+    assert len(model.entities) == 1
+    assert type(comp) == solph.Transformer
+    assert len(comp.inputs) == 1
+    assert len(comp.outputs) == 1

--- a/tests/test_var_grid.py
+++ b/tests/test_var_grid.py
@@ -34,9 +34,11 @@ def test_prepare_simulation():
     assert vg.current_ac == 4 + 0.5
 
 
-def test_create_oemof_model():
+def test_add_to_oemof_model():
     vg = VarGrid({"bus_out": "foo"})
-    model = vg.create_oemof_model({"foo": solph.Bus(label="foo")}, None)
-    assert type(model) == solph.network.Source
-    assert len(model.inputs) == 0
-    assert len(model.outputs) == 1
+    model = solph.EnergySystem()
+    comp = vg.add_to_oemof_model({"foo": solph.Bus(label="foo")}, model)
+    assert len(model.entities) == 1
+    assert type(comp) == solph.network.Source
+    assert len(comp.inputs) == 0
+    assert len(comp.outputs) == 1


### PR DESCRIPTION
Every component now implements add_to_oemof_model instead of create_oemof_model. A solph EnergySystem is required.
In the function, the oemof component is created as before, added to the given energy system and returned. In case of more complex components, a tuple may be returned.
Added docstrings and changed documentation to reflect changes.