### PR TITLE
CI: Run flake8 ASAP

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,6 +15,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install pip
+      run: |
+        python -m pip install --upgrade pip
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        flake8 smooth tests doc/source *.py
     - name: Install system dependencies
       run: |
         sudo apt-get update
@@ -22,13 +29,10 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
         pip install -r requirements.txt
-    - name: Lint with flake8
-      run: |
-        flake8 smooth tests doc/source *.py
     - name: Test with pytest
       run: |
+        pip install pytest
         pytest tests
     - name: Build documentation
       run: |


### PR DESCRIPTION
Most CI fails are caused by flake8 violations. By running flake8 as soon
as possible we can save valuable time ⏱!